### PR TITLE
Add cuML KNN for graph construction, better handling of non-PBC systems

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,12 @@ pip install poetry  # Install Poetry if you don't have it
 poetry install
 ```
 
+Optionally, also install [cuML](https://docs.rapids.ai/install/) (requires CUDA):
+```bash
+pip install --extra-index-url=https://pypi.nvidia.com "cuml-cu11==25.2.*"  # For cuda versions >=11.4, <11.8
+pip install --extra-index-url=https://pypi.nvidia.com "cuml-cu12==25.2.*"  # For cuda versions >=12.0, <13.0
+```
+
 ### Running tests
 
 The `orb_models` package uses `pytest` for testing. To run the tests, navigate to the root directory of the package and run the following command:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ pip install orb-models
 
 Orb models are expected to work on MacOS and Linux. Windows support is not guaranteed.
 
+For large system (≳5k atoms PBC, or ≳30k atoms non-PBC) simulations we recommend installing [cuML](https://docs.rapids.ai/install/) (requires CUDA), which can significantly reduce graph creation time (2-10x) and improve GPU memory efficiency (2-100x):
+```bash
+pip install --extra-index-url=https://pypi.nvidia.com "cuml-cu11==25.2.*"  # For cuda versions >=11.4, <11.8
+pip install --extra-index-url=https://pypi.nvidia.com "cuml-cu12==25.2.*"  # For cuda versions >=12.0, <13.0
+```
+
 ### Updates
 
 **Oct 2024**: We have released a new version of the models, `orb-v2`. This version has 2 major changes:

--- a/internal/check.py
+++ b/internal/check.py
@@ -4,6 +4,8 @@ import argparse
 
 import ase
 import torch
+import numpy as np
+
 from core.dataset import atomic_system as core_atomic_system
 from core.models import load
 
@@ -21,7 +23,12 @@ def main(model: str, core_model: str):
     """
     original_orbff, _, sys_config = load.load_model(core_model)
 
-    atoms = ase.Atoms("H2O", positions=[[0, 0, 0], [0, 0, 1.1], [0, 1.1, 0]])
+    atoms = ase.Atoms(
+        "H2O",
+        positions=[[0, 0, 0], [0, 0, 1.1], [0, 1.1, 0]],
+        cell=np.eye(3) * 2,
+        pbc=True,
+    )
 
     graph_orig = core_atomic_system.ase_atoms_to_atom_graphs(atoms, sys_config)
     graph = atomic_system.ase_atoms_to_atom_graphs(atoms)

--- a/orb_models/forcefield/base.py
+++ b/orb_models/forcefield/base.py
@@ -113,6 +113,12 @@ class AtomGraphs(NamedTuple):
         assert self.system_features
         self.system_features["cell"] = val
 
+    @property
+    def pbc(self):
+        """Get pbc."""
+        assert self.system_features
+        return self.system_features.get("pbc")
+
     def compute_differentiable_edge_vectors(
         self,
         use_stress_displacement: bool = True,
@@ -477,6 +483,7 @@ def refeaturize_atomgraphs(
         ) = featurization_utilities.batch_compute_pbc_radius_graph(
             positions=positions,
             cells=cell,
+            pbc=atoms.pbc,
             radius=atoms.radius,
             n_node=num_atoms,
             max_number_neighbors=atoms.max_num_neighbors,

--- a/tests/atomgraphs/test_base.py
+++ b/tests/atomgraphs/test_base.py
@@ -49,7 +49,10 @@ def graph():
         n_edge=torch.tensor([edges]),
         node_features=dict(atomic_numbers=atomic_numbers, positions=positions),
         edge_features=dict(feat=edge_features),
-        system_features={"cell": torch.eye(3).view(1, 3, 3)},
+        system_features={
+            "cell": torch.eye(3).view(1, 3, 3),
+            "pbc": torch.tensor([[True, True, True]]),
+        },
         node_targets=dict(node_target=noise_or_forces),
         edge_targets={},
         system_targets=dict(sys_target=torch.tensor([[23.3]])),

--- a/tests/atomgraphs/test_pbc_radius_graph.py
+++ b/tests/atomgraphs/test_pbc_radius_graph.py
@@ -22,11 +22,34 @@ def _matrix_to_set_of_vectors(matrix):
 
 
 @pytest.mark.parametrize(
-    "edge_method", [None] + list(typing.get_args(EdgeCreationMethod))
+    "edge_method",
+    [
+        None,
+        "knn_brute_force",
+        "knn_scipy",
+        pytest.param(
+            "knn_cuml_brute",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(),
+                reason="CUDA is not available for CuML KNN.",
+            ),
+        ),
+        pytest.param(
+            "knn_cuml_rbc",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(),
+                reason="CUDA is not available for CuML KNN.",
+            ),
+        ),
+    ],
 )
 def test_artificial_pbc_graph(edge_method):
     """Tests construct a multi graph using periodic boundary conditions."""
+    original_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("highest")
+
     positions = torch.tensor([[0.5, 0.5, 0.5]], dtype=torch.float32)
+    pbc = torch.tensor([True, True, True], dtype=torch.bool)
     radius = 1.0
     cell = torch.eye(3, dtype=torch.float32)
     out = featurization_utilities.compute_pbc_radius_graph(
@@ -34,14 +57,15 @@ def test_artificial_pbc_graph(edge_method):
         radius=radius,
         max_number_neighbors=20,
         cell=cell,
+        pbc=pbc,
         edge_method=edge_method,
     )
     edge_index, vectors, _ = out
     # There should be 6 edges, because the radius doesn't reach the corners of the grid.
     assert len(edge_index[0]) == 6
-    # # All edges should be pointing to the same index
+    # All edges should be pointing to the same index
     assert torch.all(edge_index == 0)
-    # # All edges should be of length 1.
+    # All edges should be of length 1.
     assert torch.all(torch.linalg.norm(vectors, axis=1) == 1.0)
     # Make the unit cell a 30 degree rotation.
     cell = torch.tensor(
@@ -55,6 +79,7 @@ def test_artificial_pbc_graph(edge_method):
         radius=radius + 1e-7,
         max_number_neighbors=20,
         cell=cell,
+        pbc=pbc,
         edge_method=edge_method,
     )
     edge_index, pred_rotated_vectors, _ = out
@@ -67,24 +92,46 @@ def test_artificial_pbc_graph(edge_method):
     # Rotated vectors should be the original vector but just rotated.
     # Sort to make sure aligning edge index
     pred_rotated_vectors = pred_rotated_vectors[pred_rotated_vectors[:, 0].argsort()]
-    rotated_vectors = vectors @ cell
+    rotated_vectors = vectors @ cell.to(vectors.device)
     rotated_vectors = rotated_vectors[rotated_vectors[:, 0].argsort()]
 
-    assert torch.allclose(pred_rotated_vectors, rotated_vectors)
+    torch.testing.assert_close(pred_rotated_vectors, rotated_vectors)
+    torch.set_float32_matmul_precision(original_precision)
 
 
 @pytest.mark.parametrize(
-    "edge_method", [None] + list(typing.get_args(EdgeCreationMethod))
+    "edge_method",
+    [
+        None,
+        "knn_brute_force",
+        "knn_scipy",
+        pytest.param(
+            "knn_cuml_brute",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(),
+                reason="CUDA is not available for CuML KNN.",
+            ),
+        ),
+        pytest.param(
+            "knn_cuml_rbc",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(),
+                reason="CUDA is not available for CuML KNN.",
+            ),
+        ),
+    ],
 )
 def test_CO2_graph(edge_method):
     adsorbate = get_CO2()
     positions = torch.tensor(adsorbate.positions, dtype=torch.float32)
     periodic_boundaries = torch.zeros((3, 3), dtype=torch.float32)
+    pbc = torch.tensor([True, True, True], dtype=torch.bool)
     out = featurization_utilities.compute_pbc_radius_graph(
         positions=positions,
         radius=6.0,
         max_number_neighbors=20,
         cell=periodic_boundaries,
+        pbc=pbc,
         edge_method=edge_method,
     )
     edge_index, vectors, _ = out
@@ -93,7 +140,7 @@ def test_CO2_graph(edge_method):
 
     for i in range(edge_index.shape[1]):
         matches = (
-            edge_index[:, i]
+            edge_index[:, i].cpu()
             == torch.tensor([[0, 1], [0, 2], [1, 0], [1, 2], [2, 0], [2, 1]])
         ).all(-1)
         assert matches.any()
@@ -110,40 +157,84 @@ def test_CO2_graph(edge_method):
             dtype=torch.float32,
         )
         expected_vector = expected_vectors[matches]
-        assert torch.allclose(
-            vectors[i],
-            expected_vector,
+        torch.testing.assert_close(
+            vectors[i].cpu(),
+            expected_vector[0],
         )
 
 
 @pytest.mark.parametrize("zeolite_framework", ["STW", "IFR", "VSV", "SAV"])
 @pytest.mark.parametrize(
-    "edge_method", [None] + list(typing.get_args(EdgeCreationMethod))
+    "edge_method",
+    [
+        None,
+        "knn_brute_force",
+        "knn_scipy",
+        pytest.param(
+            "knn_cuml_brute",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(),
+                reason="CUDA is not available for CuML KNN.",
+            ),
+        ),
+        pytest.param(
+            "knn_cuml_rbc",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(),
+                reason="CUDA is not available for CuML KNN.",
+            ),
+        ),
+    ],
 )
 @pytest.mark.parametrize("half_supercell", [False, True])
 def test_zeolite_graphs(fixtures_path, half_supercell, edge_method, zeolite_framework):
     """
     Compare our graph construction to nequips on real zeolite systems.
     """
+    original_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("highest")
+
     zeos = get_zeolites(fixtures_path)
     adsorbate = get_CO2()
     framework = zeos[zeolite_framework]
     atoms = framework + adsorbate
     positions = torch.from_numpy(atoms.positions).to(torch.float)
     cell = torch.Tensor(atoms.cell.array[None, ...]).to(torch.float)
+    pbc = torch.tensor(atoms.get_pbc())
 
     assert_edges_match_nequips(
         positions,
         cell,
+        pbc,
         edge_method,
         half_supercell,
         max_num_neighbors=20,
         max_radius=6.0,
     )
+    torch.set_float32_matmul_precision(original_precision)
 
 
 @pytest.mark.parametrize(
-    "edge_method", [None] + list(typing.get_args(EdgeCreationMethod))
+    "edge_method",
+    [
+        None,
+        "knn_brute_force",
+        "knn_scipy",
+        pytest.param(
+            "knn_cuml_brute",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(),
+                reason="CUDA is not available for CuML KNN.",
+            ),
+        ),
+        pytest.param(
+            "knn_cuml_rbc",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(),
+                reason="CUDA is not available for CuML KNN.",
+            ),
+        ),
+    ],
 )
 def test_thin_mp_traj_graphs(fixtures_path, edge_method):
     """
@@ -158,9 +249,11 @@ def test_thin_mp_traj_graphs(fixtures_path, edge_method):
         atoms = row.toatoms()
         positions = torch.from_numpy(atoms.positions).to(torch.float)
         cell = torch.Tensor(atoms.cell.array[None, ...]).to(torch.float)
+        pbc = torch.tensor(atoms.get_pbc())
         assert_edges_match_nequips(
             positions,
             cell,
+            pbc,
             edge_method,
             max_num_neighbors=120,
             max_radius=6.0,
@@ -168,7 +261,26 @@ def test_thin_mp_traj_graphs(fixtures_path, edge_method):
 
 
 @pytest.mark.parametrize(
-    "edge_method", [None] + list(typing.get_args(EdgeCreationMethod))
+    "edge_method",
+    [
+        None,
+        "knn_brute_force",
+        "knn_scipy",
+        pytest.param(
+            "knn_cuml_brute",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(),
+                reason="CUDA is not available for CuML KNN.",
+            ),
+        ),
+        pytest.param(
+            "knn_cuml_rbc",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(),
+                reason="CUDA is not available for CuML KNN.",
+            ),
+        ),
+    ],
 )
 def test_artificial_batched_graph(edge_method):
     """Tests batched pbc radius graph construction."""
@@ -177,15 +289,19 @@ def test_artificial_batched_graph(edge_method):
     cells = torch.broadcast_to(
         torch.eye(3, dtype=torch.float32).unsqueeze(0), (2, 3, 3)
     )
+    pbc = torch.tensor([[True, True, True], [True, True, True]], dtype=torch.bool)
     out = featurization_utilities.batch_compute_pbc_radius_graph(
         positions=positions,
         radius=radius,
         max_number_neighbors=torch.tensor([6, 6]),
         cells=cells,
+        pbc=pbc,
         n_node=torch.Tensor([1, 1]).long(),
         edge_method=edge_method,
     )
     edge_index, vectors, _, _ = out
+    edge_index = edge_index.cpu()
+    vectors = vectors.cpu()
     # There should be 6 edges per element of batch, because the radius doesn't
     # reach the corners of the grid.
     assert len(edge_index[0]) == 12
@@ -212,10 +328,13 @@ def test_artificial_batched_graph(edge_method):
         radius=radius + 1e-4,
         max_number_neighbors=torch.tensor([6, 6]),
         cells=cells,
+        pbc=pbc,
         n_node=torch.Tensor([1, 1]).long(),
         edge_method=edge_method,
     )
     edge_index, rotated_vectors, _, _ = out
+    edge_index = edge_index.cpu()
+    rotated_vectors = rotated_vectors.cpu()
     # All edges should be of length 1.
     assert torch.all((torch.linalg.norm(rotated_vectors, axis=1) - 1.0) < 1e-6)
     # Rotated vectors should be the original vector but just rotated.
@@ -223,30 +342,59 @@ def test_artificial_batched_graph(edge_method):
     # Round because of numerics and make an ndarray
     out_rotated_back_to_origin = np.around(np.array(out_rotated_back_to_origin), 5)
     # Get the sets of the two graphs
-    out_rotated_1 = _matrix_to_set_of_vectors(out_rotated_back_to_origin[:6])
-    out_rotated_2 = _matrix_to_set_of_vectors(out_rotated_back_to_origin[6:])
+    out_rotated_1 = _matrix_to_set_of_vectors(
+        np.round(out_rotated_back_to_origin[:6], decimals=3)
+    )
+    out_rotated_2 = _matrix_to_set_of_vectors(
+        np.round(out_rotated_back_to_origin[6:], decimals=3)
+    )
     # Same for original vectors
-    vectors_1 = _matrix_to_set_of_vectors(np.array(vectors[:6]))
-    vectors_2 = _matrix_to_set_of_vectors(np.array(vectors[6:]))
+    vectors = vectors.numpy()
+    vectors_1 = _matrix_to_set_of_vectors(np.round(vectors[:6], decimals=3))
+    vectors_2 = _matrix_to_set_of_vectors(np.round(vectors[6:], decimals=3))
     assert (out_rotated_1 - vectors_1) == set()
     assert (out_rotated_2 - vectors_2) == set()
 
 
 @pytest.mark.parametrize(
-    "edge_method", [None] + list(typing.get_args(EdgeCreationMethod))
+    "edge_method",
+    [
+        None,
+        "knn_brute_force",
+        "knn_scipy",
+        pytest.param(
+            "knn_cuml_brute",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(),
+                reason="CUDA is not available for CuML KNN.",
+            ),
+        ),
+        pytest.param(
+            "knn_cuml_rbc",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(),
+                reason="CUDA is not available for CuML KNN.",
+            ),
+        ),
+    ],
 )
 def test_batched_and_unbatched_equivalence(shared_fixtures_path, edge_method):
     """Tests batched pbc radius graph."""
+    original_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("highest")
+
     with (shared_fixtures_path / "atom_ocp22.json").open("r") as f:
         atoms = ase.Atoms(ase.io.read(f))
     positions = torch.tensor(atoms.get_positions()).float()
     periodic_boundaries = torch.tensor(atoms.get_cell()).float()
+    pbc = torch.tensor(atoms.get_pbc(), dtype=torch.bool)
     radius = 6.0
     max_num_neighbors = 20
 
     idx, vectors, _ = featurization_utilities.compute_pbc_radius_graph(
         positions=positions,
         cell=periodic_boundaries,
+        pbc=pbc,
         radius=radius,
         max_number_neighbors=max_num_neighbors,
         edge_method=edge_method,
@@ -256,6 +404,7 @@ def test_batched_and_unbatched_equivalence(shared_fixtures_path, edge_method):
     idx_null, vectors_null, _ = featurization_utilities.compute_pbc_radius_graph(
         positions=positions,
         cell=torch.eye(3),
+        pbc=pbc,
         radius=radius,
         max_number_neighbors=max_num_neighbors,
         edge_method=edge_method,
@@ -263,10 +412,12 @@ def test_batched_and_unbatched_equivalence(shared_fixtures_path, edge_method):
 
     positions2 = torch.cat([positions] * 2)
     periodic_boundaries2 = torch.stack([periodic_boundaries, torch.eye(3)])
+    pbc2 = torch.stack([pbc, pbc])
     out = featurization_utilities.batch_compute_pbc_radius_graph(
         positions=positions2,
         radius=radius,
         cells=periodic_boundaries2,
+        pbc=pbc2,
         n_node=torch.Tensor([96, 96]).long(),
         max_number_neighbors=torch.tensor([max_num_neighbors, max_num_neighbors]),
         edge_method=edge_method,
@@ -274,8 +425,9 @@ def test_batched_and_unbatched_equivalence(shared_fixtures_path, edge_method):
     idx2, vectors2, _, _ = out
     node_0_connections2 = idx2[1][idx2[0] == 0]
     assert set(node_0_connections2.tolist()) == set(node_0_connections.tolist())
-    assert torch.allclose(vectors, vectors2[: len(vectors)])
-    assert torch.allclose(vectors_null, vectors2[len(vectors) :])
+    torch.testing.assert_close(vectors, vectors2[: len(vectors)])
+    torch.testing.assert_close(vectors_null, vectors2[len(vectors) :])
+    torch.set_float32_matmul_precision(original_precision)
 
 
 def test_graph_vectors_are_consistent(dataset_and_loader):
@@ -285,10 +437,11 @@ def test_graph_vectors_are_consistent(dataset_and_loader):
     """
     dataloader = dataset_and_loader[1]
     batch = next(iter(dataloader))
-    assert torch.allclose(
+    torch.testing.assert_close(
         batch.compute_differentiable_edge_vectors()[0],
         batch.edge_features["vectors"],
         atol=1e-5,
+        rtol=1e-5,
     )
 
 
@@ -306,8 +459,9 @@ def test_graph_vectors_are_consistent_for_zeolites(
     atom_graph = ase_atoms_to_atom_graphs(
         system, system_config=SystemConfig(6.0, 20), half_supercell=half_supercell
     )
-    assert torch.allclose(
+    torch.testing.assert_close(
         atom_graph.compute_differentiable_edge_vectors()[0],
         atom_graph.edge_features["vectors"],
         atol=1e-5,
+        rtol=1e-5,
     )


### PR DESCRIPTION
* cuML for KNN graph construction
* Determining if a system is periodic using `ase.Atoms.pbc` _and_ `ase.Atoms.cell` rather than just `ase.Atoms.cell`. 

I've added a note to the README regarding optionally installing cuML.

I've tried adding cuml as an optional dependency in poetry such that users can `pip install orb-models[cuml-cu11]` or `pip install orb-materials[cuml-cu12]` depending on their system. But poetry tries to resolve dependencies between the two optional packages `cuml-cu11` (for cuda 11) and `cuml-cu12` (for cuda 12) and fails since they require different sub-dependencies. I don't think there is currently a way to specify mutually-exclusive optional dependencies in pip/poetry right now. So it's probably best to just have it in the README. 