### PR TITLE
Fix conservative model loading for finetuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,5 @@ datasets/
 
 # VS Code
 .devcontainer/
+
+wandb/

--- a/finetune.py
+++ b/finetune.py
@@ -19,10 +19,9 @@ except ImportError:
 from wandb import wandb_run
 
 from orb_models import utils
-from orb_models.dataset.ase_sqlite_dataset import AseSqliteDataset
-from orb_models.forcefield import base, pretrained, atomic_system, property_definitions
 from orb_models.dataset import augmentations
-
+from orb_models.dataset.ase_sqlite_dataset import AseSqliteDataset
+from orb_models.forcefield import atomic_system, base, pretrained, property_definitions
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
@@ -237,10 +236,9 @@ def run(args):
 
     # Instantiate model
     base_model = args.base_model
-    model = getattr(pretrained, base_model)(device=device, precision=precision)
-
-    for param in model.parameters():
-        param.requires_grad = True
+    model = getattr(pretrained, base_model)(
+        device=device, precision=precision, train=True
+    )
 
     model_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
     logging.info(f"Model has {model_params} trainable parameters.")

--- a/orb_models/forcefield/conservative_regressor.py
+++ b/orb_models/forcefield/conservative_regressor.py
@@ -232,7 +232,7 @@ class ConservativeForcefieldRegressor(nn.Module):
             loss_type=self.forces_loss_type,
             training=self.training,
         )
-        loss = self.loss_weights[self.grad_forces_name] * loss_out.loss
+        loss = self.loss_weights.get(self.grad_forces_name, 1.0) * loss_out.loss
         loss_out.log[f"{self.grad_forces_name}_loss"] = loss
         total_loss += loss
         metrics.update({f"{self.grad_prefix}-{k}": v for k, v in loss_out.log.items()})
@@ -246,7 +246,7 @@ class ConservativeForcefieldRegressor(nn.Module):
             normalizer=self.grad_stress_normalizer,
             loss_type=energy_head.loss_type,
         )
-        loss = self.loss_weights[self.grad_stress_name] * loss_out.loss
+        loss = self.loss_weights.get(self.grad_stress_name, 1.0) * loss_out.loss
         loss_out.log[f"{self.grad_stress_name}_loss"] = loss
         total_loss += loss
         metrics.update({f"{self.grad_prefix}-{k}": v for k, v in loss_out.log.items()})


### PR DESCRIPTION
We should not be compiling a conservative model when loading for finetuning due to limitations in PyTorch

Fixes #111.