### PR TITLE
Add dispersion models and update internal check script

### DIFF
--- a/orb_models/forcefield/pretrained.py
+++ b/orb_models/forcefield/pretrained.py
@@ -488,6 +488,70 @@ def orb_v3_direct_inf_mpa(
     return model
 
 
+def separate_d3_direct_3layer(
+    weights_path: str = "s3://orbitalmaterials-public-models/forcefields/separate-d3-3layer.ckpt",  # noqa: E501
+    device: Union[torch.device, str, None] = None,
+    precision: str = "float32-high",
+    compile: Optional[bool] = None,
+    train: bool = False,
+) -> DirectForcefieldRegressor:
+    """Load a separate D3 direct model."""
+    system_config = SystemConfig(radius=6.0, max_num_neighbors=120)
+    model = orb_v3_direct_architecture(num_message_passing_steps=3, device=device, system_config=system_config)
+    model = load_model(
+        model, weights_path, device, precision=precision, compile=compile, train=train
+    )
+    return model
+
+
+def separate_d3_direct_5layer(
+    weights_path: str = "s3://orbitalmaterials-public-models/forcefields/separate-d3-5layer.ckpt",  # noqa: E501
+    device: Union[torch.device, str, None] = None,
+    precision: str = "float32-high",
+    compile: Optional[bool] = None,
+    train: bool = False,
+) -> DirectForcefieldRegressor:
+    """Load a separate D3 direct model."""
+    system_config = SystemConfig(radius=6.0, max_num_neighbors=120)
+    model = orb_v3_direct_architecture(device=device, system_config=system_config)
+    model = load_model(
+        model, weights_path, device, precision=precision, compile=compile, train=train
+    )
+    return model
+
+
+def separate_d4_direct_3layer(
+    weights_path: str = "s3://orbitalmaterials-public-models/forcefields/separate-d4-3layer.ckpt",  # noqa: E501
+    device: Union[torch.device, str, None] = None,
+    precision: str = "float32-high",
+    compile: Optional[bool] = None,
+    train: bool = False,
+) -> DirectForcefieldRegressor:
+    """Load a separate D4 direct model."""
+    system_config = SystemConfig(radius=6.0, max_num_neighbors=120)
+    model = orb_v3_direct_architecture(num_message_passing_steps=3, device=device, system_config=system_config)
+    model = load_model(
+        model, weights_path, device, precision=precision, compile=compile, train=train
+    )
+    return model
+
+
+def separate_d4_direct_5layer(
+    weights_path: str = "s3://orbitalmaterials-public-models/forcefields/separate-d4-5layer.ckpt",  # noqa: E501
+    device: Union[torch.device, str, None] = None,
+    precision: str = "float32-high",
+    compile: Optional[bool] = None,
+    train: bool = False,
+) -> DirectForcefieldRegressor:
+    """Load a separate D4 direct model."""
+    system_config = SystemConfig(radius=6.0, max_num_neighbors=120)
+    model = orb_v3_direct_architecture(device=device, system_config=system_config)
+    model = load_model(
+        model, weights_path, device, precision=precision, compile=compile, train=train
+    )
+    return model
+
+
 def orb_v2(
     weights_path: str = "https://orbitalmaterials-public-models.s3.us-west-1.amazonaws.com/forcefields/orb-v2-20241011.ckpt",  # noqa: E501
     device: Union[torch.device, str, None] = None,
@@ -635,11 +699,16 @@ ORB_PRETRAINED_MODELS = {
     "orb-v3-conservative-inf-omat": orb_v3_conservative_inf_omat,
     "orb-v3-direct-20-omat": orb_v3_direct_20_omat,
     "orb-v3-direct-inf-omat": orb_v3_direct_inf_omat,
-    # orb-v3 mptraj + alexandria models
+    # less performant orb-v3 mptraj + alexandria models
     "orb-v3-conservative-20-mpa": orb_v3_conservative_20_mpa,
     "orb-v3-conservative-inf-mpa": orb_v3_conservative_inf_mpa,
     "orb-v3-direct-20-mpa": orb_v3_direct_20_mpa,
     "orb-v3-direct-inf-mpa": orb_v3_direct_inf_mpa,
+    # separate d3 and d4 models
+    "separate-d3-3layer": separate_d3_direct_3layer,
+    "separate-d3-5layer": separate_d3_direct_5layer,
+    "separate-d4-3layer": separate_d4_direct_3layer,
+    "separate-d4-5layer": separate_d4_direct_5layer,
     # less performant orb-v2 models
     "orb-v2": orb_v2,
     "orb-d3-v2": orb_d3_v2,


### PR DESCRIPTION
Add (direct) estimators of D3 and D4 dispersions.

There are 3 layer and 5 layer models for both D3 and D4. I am optimistic that 3-layer is sufficient for D3. I am seeing some evidence that 5 layer is more performant for D4.

Based on in-distribution validation metrics, we're optimistic the D3 calculations should be high quality. We are less sure about the quality of the D4 calculations.

The ground-truth D3 calcs were computed with the [torch_dftd](https://github.com/pfnet-research/torch-dftd) package, specifically `torch_dftd.torch_dftd3_calculator.TorchDFTD3Calculator(damping="zero", cutoff=50.2 * ase.units.Angstrom, xc="pbe")`. (In retrospect, we should have used bj damping, but we chose zero some time ago and got stuck with it to make various analyses consistent).

The ground-truth D4 calcs were computed with the [dftd4](https://github.com/dftd4/dftd4) package, specifically the `dftd4.ase.DFTD4(method="PBE", model="d4s")` calculator.