### PR TITLE
Orbmol fixes clean

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -7,7 +7,7 @@ We provide several pretrained models that can be used to calculate energies, for
 These models are a continuation of the `orb-v3` series, but are trained on the [Open Molecules 2025 (OMol25)](https://arxiv.org/pdf/2505.08762) dataset—over 100M high-accuracy DFT calculations (ωB97M-V/def2-TZVPD) on diverse molecular systems including metal complexes, biomolecules, and electrolytes.
 
 There are two options:
-* `orb-v3-conserative-omol`
+* `orb-v3-conservative-omol`
 * `orb-v3-direct-omol`
 
 See below for more explanation of this naming convention. Both models have `inf` neighbors, ensuring a continuous PES.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Alternatively, you can use Docker to run orb-models; [see instructions below](#d
 **August 2025**: Release of the OrbMol potentials (blog post forthcoming). 
 
 * Trained on the [Open Molecules 2025 (OMol25)](https://arxiv.org/pdf/2505.08762) dataset—over 100M high-accuracy DFT calculations (ωB97M-V/def2-TZVPD) on diverse molecular systems including metal complexes, biomolecules, and electrolytes.
-* Architecturally similar to the highly-performant Orb-v3 models, but now explicit total charges and spins can be passed as input.  
-* To get started with these models, see: [How to specify total charge and spin for OrbMol](#how-to-specify-total-charge-and-spin-for-orbmol).
+* Architecturally similar to the highly-performant Orb-v3 models, but now explicit total charges and spin multiplicities can be passed as input.  
+* To get started with these models, see: [How to specify total charge and spin multiplicity for OrbMol](#how-to-specify-total-charge-and-spin-multiplicity-for-orbmol).
 
 **April 2025**: Release of the [Orb-v3 set of potentials](https://arxiv.org/abs/2504.06231).
 
@@ -118,9 +118,9 @@ print("Optimized Energy:", atoms.get_potential_energy())
 
 Or you can use it to run MD simulations. The script, an example input xyz file and a Colab notebook demonstration are available in the [examples directory.](./examples) This should work with any input, simply modify the input_file and cell_size parameters. We recommend using constant volume simulations.
 
-#### How to specify total charge and spin for OrbMol
+#### How to specify total charge and spin multiplicity for OrbMol
 
-The OrbMol models *require* total charge and spin to be specified. This can be done by setting them in `atoms.info` dictionary.
+The OrbMol models *require* total charge and spin multiplicity to be specified. This can be done by setting them in `atoms.info` dictionary.
 
 ```python
 import ase
@@ -135,7 +135,7 @@ orbff = pretrained.orb_v3_conservative_omol(
 )
 atoms = molecule("C6H6")
 atoms.info["charge"] = 1.0  # total charge
-atoms.info["spin"] = 0.0  # total spin
+atoms.info["spin"] = 1.0  # multiplicity (2S+1)
 graph = atomic_system.ase_atoms_to_atom_graphs(atoms, orbff.system_config, device=device)
 
 result = orbff.predict(graph, split=False)

--- a/examples/NaClWaterMD.py
+++ b/examples/NaClWaterMD.py
@@ -54,7 +54,11 @@ def run_md_simulation(
     atoms.info["spin"] = 1.0  # multiplicity (2S+1)
 
     # Set the calculator
-    atoms.calc = ORBCalculator(pretrained.orb_v3_conservative_omol(), device=device)
+    # Note: If you encounter compilation errors (e.g., Triton issues on clusters),
+    # you can disable compilation by adding compile=False:
+    # orbff = pretrained.orb_v3_conservative_omol(device=device, compile=False)
+    orbff = pretrained.orb_v3_conservative_omol(device=device)
+    atoms.calc = ORBCalculator(orbff, device=device)
 
     # Set the initial velocities
     MaxwellBoltzmannDistribution(atoms, temperature_K=temperature_K)

--- a/examples/NaClWaterMD.py
+++ b/examples/NaClWaterMD.py
@@ -49,8 +49,12 @@ def run_md_simulation(
     atoms.set_cell([cell_size] * 3)
     atoms.set_pbc([True] * 3)
 
+    # Set charge and spin multiplicity for OrbMol models
+    atoms.info["charge"] = 0.0  # total charge
+    atoms.info["spin"] = 1.0  # multiplicity (2S+1)
+
     # Set the calculator
-    atoms.calc = ORBCalculator(pretrained.orb_v3_direct_20_omat(), device=device, compile=False)
+    atoms.calc = ORBCalculator(pretrained.orb_v3_conservative_omol(), device=device)
 
     # Set the initial velocities
     MaxwellBoltzmannDistribution(atoms, temperature_K=temperature_K)

--- a/examples/OrbMDTut.ipynb
+++ b/examples/OrbMDTut.ipynb
@@ -15,9 +15,7 @@
    "metadata": {
     "id": "_59wcfOs7Y07"
    },
-   "source": [
-    "First you need to enable the gpu under Runtime, change runtime type. Then pip install the relevant libraries:"
-   ]
+   "source": "First you need to enable the gpu under Runtime, change runtime type. Then pip install the relevant libraries:\n\n**Note:** This tutorial uses the new OrbMol models which require charge and spin multiplicity specification."
   },
   {
    "cell_type": "code",
@@ -36,9 +34,7 @@
    "metadata": {
     "id": "tc8trTdf7fV2"
    },
-   "source": [
-    "Then we need to get the example input file and run script, which are in the github repo"
-   ]
+   "source": "Then we need to get the example input file and run script from the github repo. We'll use the updated version that includes the new OrbMol models:"
   },
   {
    "cell_type": "code",
@@ -134,9 +130,7 @@
    "metadata": {
     "id": "oC2B5m12IoRN"
    },
-   "source": [
-    "It has generated 100 frames of simulation we can see it looks to be stable at 300 K"
-   ]
+   "source": "The simulation runs using the new orb-v3-conservative-omol model with proper charge and spin multiplicity specification. It generates 100 frames of simulation and should be stable at 300 K:"
   },
   {
    "cell_type": "code",
@@ -301,9 +295,7 @@
    "metadata": {
     "id": "fYASzBiSJCFI"
    },
-   "source": [
-    "Then you can run it long at a high temperatureat to see how stable it is. Or upload your own xyz file and run that just remember to update the cell size parameter and reduce the print frequency."
-   ]
+   "source": "You can run longer simulations at higher temperatures to test stability. The new OrbMol models should provide better accuracy for molecular systems. Remember to update the cell size parameter for different systems and adjust print frequencies as needed:\n\n**Note:** If you want to use your own molecular systems, make sure to set appropriate charge and spin multiplicity values in your input handling code."
   },
   {
    "cell_type": "code",

--- a/examples/OrbMDTut.ipynb
+++ b/examples/OrbMDTut.ipynb
@@ -343,18 +343,7 @@
    "metadata": {
     "id": "439fiRmBbguY"
    },
-   "source": [
-    "This script should also work on the gpu on a silicon Mac and is should be fast enough for many purposese. You probably want to load a conda environment or similar with\n",
-    "\n",
-    "```\n",
-    "conda create --name orb_env python=3.11\n",
-    "conda activate orb_env\n",
-    "\n",
-    "```\n",
-    "\n",
-    "Please reach out if you have any questions or issues. My email is tim@orbitalmaterials.com\n",
-    "Happy simulating!"
-   ]
+   "source": "You probably want to load a conda environment or similar with\n\n```\nconda create --name orb_env python=3.11\nconda activate orb_env\n\n```\n\nPlease reach out if you have any questions or issues. My email is tim@orbitalmaterials.com\nHappy simulating!"
   }
  ],
  "metadata": {


### PR DESCRIPTION
Documentation fixes:
  - Fix terminology: "total spin" → "spin multiplicity" throughout README.md
  - Update section titles and references to use correct terminology
  - Fix typo in MODELS.md: "conserative" → "conservative"

  Example updates:
  - Update NaClWaterMD.py to use orb_v3_conservative_omol() instead of orb_v3_direct_20_omat()
  - Add proper charge and spin multiplicity specification (atoms.info["charge"] and atoms.info["spin"])
  - Add helpful comment showing how to disable compilation for cluster compatibility
  - Update Jupyter notebook to mention OrbMol models and remove unsupported Mac GPU claims
