### PR TITLE
Use pypi instead of nvidia repo for cuml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ poetry install
 
 Optionally, also install [cuML](https://docs.rapids.ai/install/) (requires CUDA):
 ```bash
-pip install --extra-index-url=https://pypi.nvidia.com "cuml-cu11==25.2.*"  # For cuda versions >=11.4, <11.8
-pip install --extra-index-url=https://pypi.nvidia.com "cuml-cu12==25.2.*"  # For cuda versions >=12.0, <13.0
+pip install "cuml-cu11==25.2.*"  # For cuda versions >=11.4, <11.8
+pip install "cuml-cu12==25.2.*"  # For cuda versions >=12.0, <13.0
 ```
 
 ### Running tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN ln -s \
 
 ## Install Python requirements
 RUN pip install orb-models && \
-    pip install --extra-index-url=https://pypi.nvidia.com "cuml-cu12==25.2.*"
+    pip install "cuml-cu12==25.2.*"

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Orb models are expected to work on MacOS and Linux. Windows support is not guara
 
 For large system (≳5k atoms PBC, or ≳30k atoms non-PBC) simulations we recommend installing [cuML](https://docs.rapids.ai/install/) (requires CUDA), which can significantly reduce graph creation time (2-10x) and improve GPU memory efficiency (2-100x):
 ```bash
-pip install --extra-index-url=https://pypi.nvidia.com "cuml-cu11==25.2.*"  # For cuda versions >=11.4, <11.8
-pip install --extra-index-url=https://pypi.nvidia.com "cuml-cu12==25.2.*"  # For cuda versions >=12.0, <13.0
+pip install "cuml-cu11==25.2.*"  # For cuda versions >=11.4, <11.8
+pip install "cuml-cu12==25.2.*"  # For cuda versions >=12.0, <13.0
 ```
 
 Alternatively, you can use Docker to run orb-models; [see instructions below](#docker).


### PR DESCRIPTION
Nvidia removed some older dependencies from their python [repository](https://pypi.nvidia.com/) which broke their own dependency chain. Instead we should use the default pypi repo. 