### PR TITLE
Enable stress for orb-v3-conservative-omol

### DIFF
--- a/orb_models/forcefield/pretrained.py
+++ b/orb_models/forcefield/pretrained.py
@@ -400,7 +400,7 @@ def orb_v3_conservative_omol(
     model = orb_v3_conservative_architecture(
         device=device,
         has_charge_spin_cond=True,
-        has_stress=False,
+        has_stress=True,
     )
     model = load_model(
         model,


### PR DESCRIPTION
Set `has_stress=True` for `orb-v3-conservative-omol`. Conservative models compute stress via autograd (dE/dε/V), so no trained head is needed — this just enables the gradient computation. Unblocks NPT simulations for OMol conservative model users.

OMAT/MPA conservative models already have `has_stress=True`.