### PR TITLE
Remove squeeze to keep consistent shape

### DIFF
--- a/orb_models/forcefield/inference/orb_torchsim.py
+++ b/orb_models/forcefield/inference/orb_torchsim.py
@@ -116,7 +116,7 @@ class OrbTorchSimModel(ModelInterface):
                 continue
             _property = "energy" if property == "free_energy" else property
 
-            results[property] = torch.atleast_1d(out[_property].squeeze())
+            results[property] = torch.atleast_1d(out[_property])
 
         # Rename certain keys for the conservative model
         if self.conservative:


### PR DESCRIPTION
Squeeze can create issue of inconsistent shape.

Pratical use case:
variable cell relaxation of HCP titanium. It has only one site, so force would be reshape from [1, 3] to [3].