### PR TITLE
improve traceabaility to JAX

### DIFF
--- a/orb_models/common/atoms/batch/graph_batch.py
+++ b/orb_models/common/atoms/batch/graph_batch.py
@@ -79,7 +79,7 @@ class AtomGraphs(AbstractAtomBatch):
         # repeat_interleave, e.g. tensor[node_batch_index] instead of tensor.repeat_interleave(n_node)
         self.node_batch_index = torch.arange(
             self.n_node.shape[0], dtype=torch.int64, device=self.n_node.device
-        ).repeat_interleave(self.n_node)
+        ).repeat_interleave(self.n_node, output_size=self.positions.shape[0])
 
     def split(self: _T, clone=True) -> list["AtomGraphs"]:
         """Splits batched AtomGraphs into constituent system AtomGraphs.
@@ -218,11 +218,12 @@ class AtomGraphs(AbstractAtomBatch):
         TODO: we could cache these indices.
         """
         positions = self.node_features["positions"]
-        graph_indices = torch.zeros(len(positions), device=positions.device, dtype=torch.int)
+        n_atoms = positions.shape[0]
+        graph_indices = torch.zeros(n_atoms, device=positions.device, dtype=torch.int)
         cumsums = torch.cumsum(self.n_node, dim=0)
         graph_indices[:] = torch.searchsorted(
             cumsums,
-            torch.arange(len(positions), device=positions.device),
+            torch.arange(n_atoms, device=positions.device),
             right=True,
         )
         return graph_indices  # (natoms,)
@@ -234,9 +235,10 @@ class AtomGraphs(AbstractAtomBatch):
         """
         graph_indices = torch.zeros_like(self.senders)  # (nedges,)
         cumsums = torch.cumsum(self.n_edge, dim=0)  # (ngraphs,)
+        n_edges = self.senders.shape[0]
         graph_indices[:] = torch.searchsorted(
             cumsums,
-            torch.arange(len(self.senders), device=self.senders.device),
+            torch.arange(n_edges, device=self.senders.device),
             right=True,
         )
         return graph_indices  # (nedges,)

--- a/orb_models/common/models/segment_ops.py
+++ b/orb_models/common/models/segment_ops.py
@@ -31,7 +31,7 @@ def aggregate_nodes(
     # assert n_node.sum() == tensor.shape[0]
 
     device = tensor.device
-    count = len(n_node)
+    count = n_node.shape[0]
     if deterministic:
         import os
 
@@ -40,7 +40,7 @@ def aggregate_nodes(
         https://docs.nvidia.com/cuda/cublas/index.html#cublasApi_reproducibility"""
         os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
         torch.use_deterministic_algorithms(True)
-    segments = torch.arange(count, device=device).repeat_interleave(n_node)
+    segments = torch.arange(count, device=device).repeat_interleave(n_node, output_size=tensor.shape[0])
     if reduction == "sum":
         return scatter_sum(tensor, segments, dim=0, dim_size=count)
     elif reduction == "mean":


### PR DESCRIPTION
When tracing the model to JAX with https://github.com/cusp-ai-oss/tojax, we ideally want to use symbolic shapes for the number of atoms, number of edges and number of systems. However, `__len__` is required to be an instance of integer prohibiting the use of symbolic shapes for tracing a program in JAX. Here, we supply static shape information and replace `__len__` with `.shape[0]`.