### PR TITLE
Remove tag guard for releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
-    if: startsWith(github.ref, 'refs/tags/') 
     steps:
     - uses: actions/checkout@v4
     - name: Update version


### PR DESCRIPTION
The `gh release create` cli tool creates the tag. But at the time of release creation the tag does not exist yet, hence the workflow does not trigger due to the `if: startsWith(github.ref, 'refs/tags/')` guard. Removing it, so we can more smoothly make releases from the cli. 