### PR TITLE
Fix DirectRegressor compilation + other internal changes

### DIFF
--- a/FINETUNING_GUIDE.md
+++ b/FINETUNING_GUIDE.md
@@ -259,14 +259,14 @@ Lines starting with `#` are treated as comments and ignored.
 The script automatically handles the differences between conservative and direct models:
 
 - **Conservative models** (e.g., `orbmol_v2`):
-  - Use `grad_forces` and `grad_stress` as **loss-weight keys**
+  - Use `energy`, `forces` and `stress` as **loss-weight keys**
   - Compute forces via automatic differentiation
 
 - **Direct models** (e.g., `orb_v3_direct_omol`):
-  - Use `forces` and `stress` as **loss-weight keys**
+  - Use `energy`, `forces` and `stress` as **loss-weight keys**
   - Predict forces directly
 
-When you specify loss weights via command line (e.g., `--forces_loss_weight 10.0`), the script automatically maps this to the correct key (`grad_forces` for conservative models, `forces` for direct models).
+You can specify loss weights via command line (e.g., `--forces_loss_weight 10.0`).
 
 ## Using the API Directly (Without the Finetuning Script)
 
@@ -283,19 +283,8 @@ model, atoms_adapter = pretrained.orbmol_v2(
     train_reference_energies=True,  # Make reference energies trainable
     loss_weights={
         'energy': 1.0,
-        'grad_forces': 10.0,      # Use 'grad_forces' for conservative models
-        'grad_stress': 100.0       # Use 'grad_stress' for conservative models
-    }
-)
-
-# For direct models, use 'forces' and 'stress' keys:
-model, atoms_adapter = pretrained.orb_v3_direct_omol(
-    device='cuda',
-    train=True,
-    loss_weights={
-        'energy': 1.0,
-        'forces': 10.0,    # Use 'forces' for direct models
-        'stress': 100.0    # Use 'stress' for direct models  
+        'forces': 10.0,
+        'stress': 100.0
     }
 )
 
@@ -333,7 +322,7 @@ You can also specify loss weights when loading for further finetuning:
 # Load for continued finetuning with different loss weights
 model, atoms_adapter = pretrained.orbmol_v2(
     train=True,
-    loss_weights={'energy': 0.5, 'grad_forces': 20.0}
+    loss_weights={'energy': 0.5, 'forces': 20.0}
 )
 model.load_state_dict(torch.load('path/to/finetuned_checkpoint.pt'))
 ```
@@ -390,7 +379,7 @@ model, atoms_adapter = pretrained.orbmol_v2(
     train_reference_energies=False,  # Fixed reference energies
     loss_weights={
         'energy': 1.0,
-        'grad_forces': 10.0,
+        'forces': 10.0,
     }
 )
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ result = orbff.predict(graph, split=False)
 # Convert to ASE atoms (unbatches the results and transfers to cpu if necessary)
 atoms = graph.to_ase_atoms(
     energy=result["energy"],
-    forces=result["grad_forces"],
-    stress=result["grad_stress"]
+    forces=result["forces"],
+    stress=result["stress"]
 )
 ```
 

--- a/finetune.py
+++ b/finetune.py
@@ -460,12 +460,10 @@ def run(args):
         loss_weights["energy"] = args.energy_loss_weight
 
     if args.forces_loss_weight is not None:
-        key = "grad_forces" if is_conservative_model else "forces"
-        loss_weights[key] = args.forces_loss_weight
+        loss_weights["forces"] = args.forces_loss_weight
 
     if args.stress_loss_weight is not None:
-        key = "grad_stress" if is_conservative_model else "stress"
-        loss_weights[key] = args.stress_loss_weight
+        loss_weights["stress"] = args.stress_loss_weight
 
     if args.equigrad_loss_weight is not None:
         if not is_conservative_model:
@@ -700,13 +698,13 @@ def main():
         "--forces_loss_weight",
         default=None,
         type=float,
-        help="Weight for forces loss. Automatically uses 'forces' or 'grad_forces' depending on model type. If not specified, defaults to 1.0.",
+        help="Weight for forces loss. If not specified, defaults to 1.0.",
     )
     parser.add_argument(
         "--stress_loss_weight",
         default=None,
         type=float,
-        help="Weight for stress loss. Automatically uses 'stress' or 'grad_stress' depending on model type. Set to 0 to disable stress training. If not specified, defaults to 1.0.",
+        help="Weight for stress loss. Set to 0 to disable stress training. If not specified, defaults to 1.0.",
     )
     parser.add_argument(
         "--equigrad_loss_weight",

--- a/orb_models/common/atoms/graph_featurization.py
+++ b/orb_models/common/atoms/graph_featurization.py
@@ -10,6 +10,8 @@ from nvalchemiops.torch.neighbors import neighbor_list as nva_neighbor_list
 from nvalchemiops.torch.neighbors.neighbor_utils import get_neighbor_list_from_neighbor_matrix
 from scipy.spatial import KDTree as SciKDTree
 
+from orb_models.common.torch_utils import get_device
+
 try:
     import cuml  # type: ignore
 except Exception:
@@ -17,7 +19,7 @@ except Exception:
 
 from orb_models.common import TORCH_FLOAT_DTYPES
 from orb_models.common.models.segment_ops import aggregate_nodes
-from orb_models.common.torch_utils import get_device, torch_lexsort
+from orb_models.common.torch_utils import torch_lexsort
 
 EdgeCreationMethod = Literal[
     "knn_brute_force",
@@ -735,6 +737,11 @@ def _compute_neighbor_list_with_fallback(
 
     See: https://nvidia.github.io/warp/modules/sim.html#neighbor-finding
     """
+    # nvalchemiops produces incorrect results when pbc has shape (3,) for batched inputs
+    # so we expand it to (n_systems, 3). We can remove this once it's fixed.
+    n_systems = cell.shape[0] if cell.dim() == 3 else 1
+    pbc = pbc.view(-1, 3).expand(n_systems, 3).contiguous()
+
     for safety_factor in [initial_safety_factor, fallback_safety_factor]:
         max_num_neighbors_alchemi = estimate_max_neighbors(
             cutoff, atomic_density=atomic_density, safety_factor=safety_factor

--- a/orb_models/common/models/base.py
+++ b/orb_models/common/models/base.py
@@ -43,6 +43,16 @@ class ModelMixin[T: AbstractAtomBatch](torch.nn.Module):
 class RegressorModelMixin[T: AbstractAtomBatch](ModelMixin[T]):
     """Model Mixin for our regression models."""
 
-    def predict(self, batch: T, split: bool) -> dict[str, torch.Tensor]:
-        """Predicts a set of properties."""
+    def predict(
+        self,
+        batch: T,
+        split: bool = False,
+        **kwargs,
+    ) -> dict[str, torch.Tensor]:
+        """Predicts a set of properties.
+
+        Args:
+            batch: Input batch.
+            split: If True, split predictions per graph.
+        """
         raise NotImplementedError()

--- a/orb_models/common/models/graph_regressor.py
+++ b/orb_models/common/models/graph_regressor.py
@@ -32,7 +32,6 @@ class RegressionHead(torch.nn.Module, abc.ABC):
         self,
         pred: torch.Tensor,
         batch: AbstractAtomBatch,
-        alternative_target: torch.Tensor | None = None,
     ) -> base.ModelOutput: ...
 
 
@@ -103,42 +102,37 @@ class GraphHead(RegressionHead):
         self.real_loss_type = real_loss_type
 
     def forward(self, node_features: torch.Tensor, batch: AbstractAtomBatch) -> torch.Tensor:
-        """Predictions with raw logits (no sigmoid/softmax or any inverse transformations)."""
+        """Return predictions. Physical units for real domain, raw logits for binary/categorical."""
         input = segment_ops.aggregate_nodes(
             node_features,
             batch.n_node,
             reduction=self.node_aggregation,
         )
         pred = self.mlp(input)
+        if self.target.domain == "real":
+            return self.normalizer.inverse(pred)
         return pred
 
     def predict(self, node_features: torch.Tensor, batch: AbstractAtomBatch) -> torch.Tensor:
         """Predict graph-level attribute."""
-        pred = self(node_features, batch)
-        logits = pred.squeeze(-1)
-        probs = self.output_activation(logits)
-        if self.target.domain == "real":
-            probs = self.normalizer.inverse(probs)
-        return probs
+        pred = self(node_features, batch).squeeze(-1)
+        if self.target.domain != "real":
+            pred = self.output_activation(pred)
+        return pred
 
     def loss(
         self,
         pred: torch.Tensor,
         batch: AbstractAtomBatch,
-        alternative_target: torch.Tensor | None = None,
     ):
-        """Apply mlp to compute loss and metrics.
+        """Compute loss and metrics.
 
-        Depending on whether the target is real/binary/categorical, we
-        use an MSE/cross-entropy loss. In the case of cross-entropy, the
-        preds are logits (not normalized) to take advantage of numerically
-        stable log-softmax.
+        For real domain, pred is in physical units (from forward). For
+        binary/categorical, pred is raw logits for numerically stable
+        log-softmax / BCE.
         """
         name = self.target.fullname
-        if alternative_target is not None:
-            target = alternative_target
-        else:
-            target = batch.system_targets[name].squeeze(-1)
+        target = batch.system_targets[name].squeeze(-1)
         pred = pred.squeeze(-1)
 
         if self.target.domain == "categorical":
@@ -151,12 +145,12 @@ class GraphHead(RegressionHead):
         else:
             assert pred.shape == target.shape, f"{pred.shape} != {target.shape}"
             normalized_target = self.normalizer(target)
-            loss = mean_error(pred, normalized_target, self.real_loss_type)
-            raw_pred = self.normalizer.inverse(pred)
+            normalized_pred = self.normalizer(pred, online=False)
+            loss = mean_error(normalized_pred, normalized_target, self.real_loss_type)
             metrics = {
                 f"{name}_loss": loss,
-                f"{name}_mae_raw": torch.abs(raw_pred - target).mean(),
-                f"{name}_mse_raw": ((raw_pred - target) ** 2).mean(),
+                f"{name}_mae_raw": torch.abs(pred - target).mean(),
+                f"{name}_mse_raw": ((pred - target) ** 2).mean(),
             }
 
         return base.ModelOutput(loss=loss, log=metrics)

--- a/orb_models/forcefield/inference/calculator.py
+++ b/orb_models/forcefield/inference/calculator.py
@@ -6,18 +6,8 @@ from orb_models.common.atoms.graph_featurization import EdgeCreationMethod
 from orb_models.common.models.nn_util import ChargeSpinConditioner
 from orb_models.common.torch_utils import to_numpy
 from orb_models.forcefield.inference.d3_model import D3SumModel
-from orb_models.forcefield.models.conservative_regressor import (
-    ConservativeForcefieldRegressor,
-)
+from orb_models.forcefield.models.conservative_regressor import ConservativeForcefieldRegressor
 from orb_models.forcefield.models.direct_regressor import DirectForcefieldRegressor
-
-
-def _is_conservative(
-    model: DirectForcefieldRegressor | ConservativeForcefieldRegressor | D3SumModel,
-) -> bool:
-    if isinstance(model, D3SumModel):
-        model = model.xc_model
-    return isinstance(model, ConservativeForcefieldRegressor)
 
 
 class ORBCalculator(Calculator):
@@ -40,7 +30,7 @@ class ORBCalculator(Calculator):
             model: The Orb forcefield model to use for predictions.
             atoms_adapter: The adapter to convert between ASE Atoms and AtomGraphs.
             edge_method (EdgeCreationMethod, optional): The method to use for graph edge construction. Defaults to knn_alchemi.
-            max_number_neighbors (int): The maximum number of neighbors for each atom.
+            max_num_neighbors (int): The maximum number of neighbors for each atom.
                 Larger values should generally increase performace, but the gains may be marginal,
                 whilst the increse in latency could be significant (depending on num atoms).
                     - Defaults to atoms_adapter.max_num_neighbors.
@@ -62,7 +52,6 @@ class ORBCalculator(Calculator):
         self.max_num_neighbors = max_num_neighbors
         self.edge_method = edge_method
         self.half_supercell = half_supercell
-        self.conservative = _is_conservative(model)
 
         conditioner = (
             model.xc_model.model.conditioner
@@ -74,10 +63,25 @@ class ORBCalculator(Calculator):
         )
 
         self.implemented_properties = model.properties  # type: ignore
-        if self.conservative:
-            self.implemented_properties.append("forces")
-            if self.model.has_stress:
-                self.implemented_properties.append("stress")
+
+    def check_state(self, atoms, tol=1e-15):
+        """Check if calculation is needed.
+
+        Extends ASE's default check to also detect changes in charge/spin,
+        which are stored in atoms.info and not tracked by ASE's default
+        change detection (positions, numbers, cell, pbc).
+        """
+        system_changes = Calculator.check_state(self, atoms, tol)
+        if self.expects_charge_and_spin and self.atoms is not None:
+            old_charge = self.atoms.info.get("charge")
+            old_spin = self.atoms.info.get("spin")
+            new_charge = atoms.info.get("charge")
+            new_spin = atoms.info.get("spin")
+            if (
+                old_charge != new_charge or old_spin != new_spin
+            ) and "positions" not in system_changes:
+                system_changes.append("positions")
+        return system_changes
 
     def calculate(self, atoms=None, properties=None, system_changes=all_changes):
         """Calculate properties.
@@ -111,33 +115,14 @@ class ORBCalculator(Calculator):
     def _update_results(self, out: dict[str, torch.Tensor]):
         """Updates the results dictionary with the computed properties."""
         self.results = {}
-        model = self.model.xc_model if isinstance(self.model, D3SumModel) else self.model
-        no_direct_energy_head = "energy" not in model.heads  # type: ignore
-        no_direct_force_head = "forces" not in model.heads  # type: ignore
-        no_direct_stress_head = "stress" not in model.heads  # type: ignore
-        for property in self.implemented_properties:
-            if property == "free_energy" and no_direct_energy_head:
+        for prop in self.implemented_properties:
+            out_key = "energy" if prop == "free_energy" else prop
+            if out_key not in out:
                 continue
-            if property == "forces" and no_direct_force_head:
-                continue
-            if property == "stress" and no_direct_stress_head:
-                continue
-            _property = "energy" if property == "free_energy" else property
-
             # ASE expects:
             #  - stresses to be squeezed to a 1D array of shape (6,)
             #  - forces to never be squeezed i.e. single-atom systems should be (1, 3)
-            if property == "stress" or property == "grad_stress":
-                self.results[property] = to_numpy(out[_property].squeeze())
+            if prop == "stress":
+                self.results[prop] = to_numpy(out[out_key].squeeze())
             else:
-                self.results[property] = to_numpy(out[_property])
-
-        if self.conservative:
-            if model.forces_name in self.results:
-                self.results["direct_forces"] = self.results[model.forces_name]
-            self.results["forces"] = self.results[model.grad_forces_name]
-
-            if model.has_stress:
-                if model.stress_name in self.results:
-                    self.results["direct_stress"] = self.results[model.stress_name]
-                self.results["stress"] = self.results[model.grad_stress_name]
+                self.results[prop] = to_numpy(out[out_key])

--- a/orb_models/forcefield/inference/d3_model.py
+++ b/orb_models/forcefield/inference/d3_model.py
@@ -97,10 +97,23 @@ class AlchemiDFTD3(torch.nn.Module):
         self.register_buffer("c6_reference", d3_params.c6ab.float(), persistent=True)
         self.register_buffer("coord_num_ref", d3_params.cn_ref.float(), persistent=True)
 
-    def predict(self, batch: AtomGraphs, split: bool = False) -> dict[str, torch.Tensor]:
+    def predict(
+        self,
+        batch: AtomGraphs,
+        split: bool = False,
+        *,
+        compute_forces: bool = True,
+        compute_stress: bool = True,
+    ) -> dict[str, torch.Tensor]:
         """Predict by summing outputs from both XC and D3 models."""
         out = self(
-            batch.positions, batch.cell, batch.atomic_numbers, batch.pbc, batch.node_batch_index
+            batch.positions,
+            batch.cell,
+            batch.atomic_numbers,
+            batch.pbc,
+            batch.node_batch_index,
+            compute_forces=compute_forces,
+            compute_stress=compute_stress,
         )
 
         if split:
@@ -109,9 +122,19 @@ class AlchemiDFTD3(torch.nn.Module):
         return out
 
     def forward(
-        self, positions, cell, atomic_numbers, pbc, node_batch_index
+        self,
+        positions,
+        cell,
+        atomic_numbers,
+        pbc,
+        node_batch_index,
+        *,
+        compute_forces: bool = True,
+        compute_stress: bool = True,
     ) -> dict[str, torch.Tensor]:
-        """Compute DFT-D3 dispersion energy and forces."""
+        """Compute DFT-D3 dispersion energy, and optionally forces and stress."""
+        compute_stress = compute_stress and self.has_stress
+
         with torch.inference_mode():
             # Convert inputs to atomic units
             cell_angstrom = cell.contiguous()
@@ -155,19 +178,21 @@ class AlchemiDFTD3(torch.nn.Module):
                 k3=self.k3,
                 s5_smoothing_on=self.s5_smoothing_on,
                 s5_smoothing_off=self.s5_smoothing_off,
-                compute_virial=self.has_stress,
+                compute_virial=compute_stress,
             )
-            if self.has_stress:
-                energy, forces, coord_num, virial = d3_out
+            if compute_stress:
+                energy, forces, _coord_num, virial = d3_out
             else:
-                energy, forces, coord_num = d3_out
+                energy, forces, _coord_num = d3_out
 
             # Convert outputs back to conventional units
             # Energy: Hartree -> eV
             energy = energy * HARTREE_TO_EV
+            out: dict[str, torch.Tensor] = {"energy": energy}
             # Forces: Hartree/Bohr -> eV/Angstrom
-            forces = forces * (HARTREE_TO_EV / BOHR_TO_ANGSTROM)
-            if self.has_stress:
+            if compute_forces:
+                out["forces"] = forces * (HARTREE_TO_EV / BOHR_TO_ANGSTROM)
+            if compute_stress:
                 # Virial is in Hartree, convert to eV
                 virial = virial * HARTREE_TO_EV
                 # Convert to stress tensor (units: eV/Å³)
@@ -175,13 +200,8 @@ class AlchemiDFTD3(torch.nn.Module):
                 stress = -virial / volume.view(-1, 1, 1)
                 # Convert full stress matrix [N, 3, 3] to Voigt notation [N, 6]
                 stress_voigt = torch_full_3x3_to_voigt_6_stress(stress)
-
-            out = {
-                "energy": energy,
-                "forces": forces,
-            }
-            if self.has_stress:
                 out["stress"] = stress_voigt
+
         return out
 
     def extra_repr(self) -> str:
@@ -321,61 +341,38 @@ class D3SumModel(RegressorModelMixin):
         """Check if the model has stress prediction."""
         return self.xc_model.has_stress
 
-    def predict(self, batch: AtomGraphs, split: bool = False) -> dict[str, torch.Tensor]:
+    def predict(
+        self,
+        batch: AtomGraphs,
+        split: bool = False,
+        *,
+        compute_forces: bool = True,
+        compute_stress: bool = True,
+        **kwargs,
+    ) -> dict[str, torch.Tensor]:
         """Predict by summing outputs from both XC and D3 models.
-
-        Handles the special naming conventions for conservative models where
-        forces/stress may have grad_ prefixes or level-of-theory suffixes.
 
         Args:
             batch: Input batch of atomic structures
             split: Whether to split predictions by system
+            compute_forces: Whether to compute forces.
+            compute_stress: Whether to compute stress.
 
         Returns:
             Dictionary with summed predictions, including energy, forces, and stress
         """
-        # Get predictions from both models
-        xc_out = self.xc_model.predict(batch, split=split)
-        d3_out = self.d3_model.predict(batch, split=split)
+        xc_out = self.xc_model.predict(
+            batch, split=split, compute_forces=compute_forces, compute_stress=compute_stress
+        )
+        d3_out = self.d3_model.predict(
+            batch, split=split, compute_forces=compute_forces, compute_stress=compute_stress
+        )
 
-        # Start with XC model output
         out: dict[str, torch.Tensor] = xc_out.copy()
-
-        # Sum energy predictions
         out["energy"] = out["energy"] + d3_out["energy"]
-
-        # Sum force predictions (handling conservative naming)
-        if "forces" in d3_out:
-            if isinstance(self.xc_model, ConservativeForcefieldRegressor):
-                # For conservative models, add to the gradient-based forces
-                grad_forces_key: str = self.xc_model.grad_forces_name
-                if grad_forces_key in out:
-                    out[grad_forces_key] = out[grad_forces_key] + d3_out["forces"]
-
-                # Also add to direct forces if they exist
-                forces_key: str = self.xc_model.forces_name
-                if forces_key in out:
-                    out[forces_key] = out[forces_key] + d3_out["forces"]
-            else:
-                # For direct models, simple addition
-                if "forces" in out:
-                    out["forces"] = out["forces"] + d3_out["forces"]
-
-        # Sum stress predictions (handling conservative naming)
-        if "stress" in d3_out and self.xc_model.has_stress:
-            if isinstance(self.xc_model, ConservativeForcefieldRegressor):
-                # For conservative models, add to the gradient-based stress
-                grad_stress_key: str = self.xc_model.grad_stress_name  # type: ignore
-                if grad_stress_key in out:
-                    out[grad_stress_key] = out[grad_stress_key] + d3_out["stress"]
-
-                # Also add to direct stress if it exists
-                stress_key: str = self.xc_model.stress_name  # type: ignore
-                if stress_key in out:
-                    out[stress_key] = out[stress_key] + d3_out["stress"]
-            else:
-                # For direct models, simple addition
-                if "stress" in out:
-                    out["stress"] = out["stress"] + d3_out["stress"]
+        if "forces" in out and "forces" in d3_out:
+            out["forces"] = out["forces"] + d3_out["forces"]
+        if "stress" in out and "stress" in d3_out:
+            out["stress"] = out["stress"] + d3_out["stress"]
 
         return out

--- a/orb_models/forcefield/inference/orb_torchsim.py
+++ b/orb_models/forcefield/inference/orb_torchsim.py
@@ -12,7 +12,6 @@ import torch
 
 from orb_models.common.atoms.graph_featurization import EdgeCreationMethod
 from orb_models.forcefield.forcefield_adapter import ForcefieldAtomsAdapter
-from orb_models.forcefield.inference.calculator import _is_conservative
 from orb_models.forcefield.inference.d3_model import D3SumModel
 from orb_models.forcefield.models.conservative_regressor import ConservativeForcefieldRegressor
 from orb_models.forcefield.models.direct_regressor import DirectForcefieldRegressor
@@ -44,25 +43,16 @@ class OrbTorchSimModel(ModelInterface):
         self._device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self._dtype = dtype
 
-        # Set up system configuration
         self.atoms_adapter = atoms_adapter
         self.edge_method = edge_method
-        self.conservative = _is_conservative(model)
 
-        # Set device and dtype
         self.model = model.to(self._device)  # type: ignore
         self.model = self.model.eval()
         if self.dtype is not None:
             self.model = self.model.to(dtype=self.dtype)
 
-        # Set up implemented properties
         self.implemented_properties = self.model.properties
-        if self.conservative:
-            self.implemented_properties.extend(["forces"])
-            if self.model.has_stress:
-                self.implemented_properties.append("stress")
 
-        # Set flags for TorchSim
         self._compute_stress = "stress" in self.implemented_properties
         self._compute_forces = "forces" in self.implemented_properties
 
@@ -103,31 +93,11 @@ class OrbTorchSimModel(ModelInterface):
     def _get_results(self, out: dict[str, torch.Tensor]):
         """Parses the results into a final output dictionary."""
         results = {}
-        model = self.model.xc_model if isinstance(self.model, D3SumModel) else self.model
-        no_direct_energy_head = "energy" not in model.heads  # type: ignore
-        no_direct_force_head = "forces" not in model.heads  # type: ignore
-        no_direct_stress_head = "stress" not in model.heads  # type: ignore
-        for property in self.implemented_properties:
-            if property == "free_energy" and no_direct_energy_head:
+        for prop in self.implemented_properties:
+            out_key = "energy" if prop == "free_energy" else prop
+            if out_key not in out:
                 continue
-            if property == "forces" and no_direct_force_head:
-                continue
-            if property == "stress" and no_direct_stress_head:
-                continue
-            _property = "energy" if property == "free_energy" else property
-
-            results[property] = torch.atleast_1d(out[_property])
-
-        # Rename certain keys for the conservative model
-        if self.conservative:
-            if model.forces_name in results:
-                results["direct_forces"] = results[model.forces_name]
-            results["forces"] = results[model.grad_forces_name]
-
-            if model.has_stress:
-                if model.stress_name in results:
-                    results["direct_stress"] = results[model.stress_name]
-                results["stress"] = results[model.grad_stress_name]
+            results[prop] = torch.atleast_1d(out[out_key])
 
         # Ensure stress has shape [-1, 3, 3]
         if "stress" in results and results["stress"].shape[-1] == 6:

--- a/orb_models/forcefield/models/conservative_regressor.py
+++ b/orb_models/forcefield/models/conservative_regressor.py
@@ -4,7 +4,6 @@ from typing import Any, Literal, cast
 import torch
 
 from orb_models.common.atoms.batch.graph_batch import AtomGraphs
-from orb_models.common.dataset.property_definitions import PROPERTIES, PropertyDefinition
 from orb_models.common.models import base
 from orb_models.common.models.gns import MoleculeGNS
 from orb_models.common.models.graph_regressor import _validate_heads_and_loss_weights
@@ -18,10 +17,7 @@ from orb_models.forcefield.models.forcefield_heads import (
     EnergyHead,
     ForcefieldHead,
 )
-from orb_models.forcefield.models.forcefield_utils import (
-    compute_gradient_forces_and_stress,
-    torch_full_3x3_to_voigt_6_stress,
-)
+from orb_models.forcefield.models.forcefield_utils import compute_gradient_forces_and_stress
 from orb_models.forcefield.models.loss import forces_loss_function, stress_loss_function
 from orb_models.forcefield.models.pair_repulsion import ZBLBasis
 
@@ -35,11 +31,8 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
     Args:
         heads: A mapping of head names to heads.
         model: A pretrained model to use for transfer learning/finetuning.
-        loss_weights: The weight of the energy loss in the total loss.
-            Additionally, the conservative model must also have two keys:
-                - "grad_forces"
-                - "grad_stress"
-            which weight the gradient based losses of forces/stress respectively.
+        loss_weights: The weight of each loss term. Expected keys:
+                - "energy", "forces", "stress", and optionally "rotational_grad".
         coulomb_module: Optional CoulombModule for long-range electrostatics.
             When present, a latent_charges head must also be in heads.
         **kwargs: Additional kwargs, used for backwards compatibility of deprecated arguments.
@@ -57,7 +50,6 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
         model: MoleculeGNS,
         loss_weights: dict[str, float] | None = None,
         online_normalisation: bool = True,
-        level_of_theory: str | None = None,
         forces_loss_type: Literal["mae", "mse", "huber_0.01", "condhuber_0.01"] = "condhuber_0.01",
         pair_repulsion: bool = False,
         has_stress: bool = True,
@@ -71,15 +63,19 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
                     f"Unknown kwargs: {kwarg}, expected only backward compatible kwargs "
                     f"from {self._deprecated_kwargs}"
                 )
+        heads = {k: v for k, v in heads.items() if v is not None}
         if "energy" not in heads:
             raise ValueError("Missing required energy head.")
 
         loss_weights = loss_weights or {}
         loss_weights = {k: v for k, v in loss_weights.items() if v is not None}
+        # BC: rename old grad-prefixed loss weight keys
+        _bc = {"grad_forces": "forces", "grad_stress": "stress"}
+        loss_weights = {_bc.get(k, k): v for k, v in loss_weights.items()}
         nongrad_loss_weights = {
             k: v
             for k, v in loss_weights.items()
-            if k not in ["grad_forces", "grad_stress", "rotational_grad"]
+            if k not in ["forces", "stress", "rotational_grad"]
         }
         _validate_heads_and_loss_weights(heads, nongrad_loss_weights)
 
@@ -101,31 +97,12 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
                 "CoulombModule requires a 'latent_charges' head in heads"
             )
 
-        # Target names
-        self.energy_name = heads["energy"].target.fullname
-        self.grad_prefix = "grad"
-
-        self.forces_name = f"forces-{level_of_theory}" if level_of_theory else "forces"
-        self.forces_target = PROPERTIES[self.forces_name]
-        self.grad_forces_name = f"{self.grad_prefix}_{self.forces_name}"
-
-        # Stress is optional since only periodic systems have it
         self.has_stress = has_stress
-        if self.has_stress:
-            self.stress_name: str | None = (
-                f"stress-{level_of_theory}" if level_of_theory else "stress"
-            )
-            self.stress_target: PropertyDefinition | None = PROPERTIES[self.stress_name]
-            self.grad_stress_name: str | None = f"{self.grad_prefix}_{self.stress_name}"
-        else:
-            self.stress_name = None
-            self.stress_target = None
-            self.grad_stress_name = None
-        assert self.has_stress == (self.grad_stress_name is not None), (
-            "grad_stress_name must be set if has_stress is True"
-        )
 
-        self.grad_rotation_name = "rotational_grad"
+        collisions = {"forces", "stress"} & heads.keys()
+        assert not collisions, (
+            f"Heads {collisions} collide with gradient-based prediction keys in predict()."
+        )
 
         self.extra_properties = []
         for name in heads.keys() - {"energy", "latent_charges", "latent_spins"}:
@@ -134,12 +111,7 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
 
     def enable_stress(self) -> None:
         """Enable stress computation. No-op if already enabled."""
-        if self.has_stress:
-            return
         self.has_stress = True
-        self.stress_name = "stress"
-        self.stress_target = PROPERTIES["stress"]
-        self.grad_stress_name = f"{self.grad_prefix}_{self.stress_name}"
 
     def prepare_for_inference(self) -> None:
         """Enable stress for inference — always available via autograd."""
@@ -150,37 +122,77 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
         self.has_stress = False
 
     @property
-    def properties(self):
-        """List of names of predicted properties."""
-        props = [
-            self.energy_name,
-            "free_energy",
-            self.grad_forces_name,
-            self.grad_rotation_name,
-        ]
+    def properties(self) -> list[str]:
+        """Canonical names of properties available from predict()."""
+        props = ["energy", "free_energy", "forces"]
         if self.has_stress:
-            assert self.grad_stress_name is not None, (
-                "grad_stress_name must be set if has_stress is True"
-            )
-            props.append(self.grad_stress_name)
+            props.append("stress")
         props.extend(self.extra_properties)
         return props
 
-    def forward(self, batch: AtomGraphs) -> dict[str, torch.Tensor]:
-        """Forward pass computing both direct and conservative predictions."""
-        vectors, stress_displacement, generator = batch.compute_differentiable_edge_vectors()
-        assert stress_displacement is not None
-        assert generator is not None
-        batch.system_features["stress_displacement"] = stress_displacement
-        batch.system_features["generator"] = generator
-        batch.edge_features["vectors"] = vectors
+    @property
+    def autograd_derivative_keys(self) -> frozenset[str]:
+        """Forward() output keys computed via autograd on the energy.
 
-        # Get base model features
+        Pipeline frameworks use this to know which outputs they should compute via their own
+        autograd pass rather than reading from the model directly.
+        """
+        keys: set[str] = {"forces"}
+        if self.has_stress:
+            keys.add("stress")
+        return frozenset(keys)
+
+    @property
+    def analytic_derivative_keys(self) -> frozenset[str]:
+        """Forward() output keys for spatial derivatives that cannot be computed via autograd.
+
+        Returns the dict keys of analytically computed derivatives (e.g. from Coulomb PME)
+        that are *not* obtained via autograd on the energy, and should be added to the gradient-based forces/stress.
+        """
+        if self.coulomb_module is not None:
+            keys = {"analytic_forces"}
+            if self.has_stress:
+                keys.add("analytic_stress")
+            return frozenset(keys)
+        return frozenset()
+
+    def forward(
+        self,
+        batch: AtomGraphs,
+        *,
+        compute_forces: bool = True,
+        compute_stress: bool = True,
+        fp64_energy: bool = True,
+    ) -> dict[str, torch.Tensor]:
+        """Compute absolute energy and conservative forces/stress.
+
+        Returns a dict with total quantities and their components:
+
+            Totals (consumer-facing):
+                "energy"              — absolute energy (B,); fp64 when fp64_energy=True
+                "forces"              — total forces (N, 3), autograd + explicit
+                "stress"              — total stress (B, 6) in Voigt notation
+
+            Components (used by loss and pipeline frameworks):
+                "interaction_energy"  — energy without reference (B,)
+                "rotational_grad"     — equivariance regularisation gradient (B, 3, 3)
+                "analytic_forces"     — non-autograd forces, e.g. Coulomb (N, 3)
+                "analytic_stress"     — non-autograd stress, e.g. Coulomb (B, 6)
+        """
+        compute_stress = compute_stress and self.has_stress
+
+        if compute_forces or compute_stress:
+            vectors, stress_displacement, generator = batch.compute_differentiable_edge_vectors()
+            assert stress_displacement is not None
+            assert generator is not None
+            batch.system_features["stress_displacement"] = stress_displacement
+            batch.system_features["generator"] = generator
+            batch.edge_features["vectors"] = vectors
+
         out = self.model(batch)
         node_features = out["node_features"]
 
-        # Predict per-atom charges/spins BEFORE energy head so they can
-        # be used as conditioning features in ChargeConditionedEnergyHead and CoulombModule.
+        # Latent charges (and spins) are fed into the energy head
         latent_charges = None
         if "latent_charges" in self.heads:
             latent_charges = self.heads["latent_charges"](node_features, batch)
@@ -189,7 +201,7 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
         if "latent_spins" in self.heads:
             latent_spins = self.heads["latent_spins"](node_features, batch)
 
-        energy_head = self.heads[self.energy_name]
+        energy_head = self.heads["energy"]
         energy_head = cast(ForcefieldHead, energy_head)
         if isinstance(energy_head, ChargeConditionedEnergyHead):
             interaction_energy = energy_head(
@@ -204,49 +216,43 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
         if self.pair_repulsion:
             interaction_energy += self.pair_repulsion_fn(batch)["energy"]
 
-        coulomb_explicit_forces = None
-        coulomb_explicit_virial = None
         if self.coulomb_module is not None:
             assert latent_charges is not None, "CoulombModule requires a LatentChargeHead"
-            coulomb_energy, coulomb_explicit_forces, coulomb_explicit_virial = self.coulomb_module(
-                latent_charges, batch
+            coulomb_energy, explicit_forces, explicit_stress = self.coulomb_module(
+                latent_charges, batch, compute_forces=True, compute_stress=self.has_stress
             )
             interaction_energy = interaction_energy + coulomb_energy
+            out["analytic_forces"] = explicit_forces
+            if explicit_stress is not None:
+                out["analytic_stress"] = explicit_stress
 
-        out[self.energy_name] = interaction_energy
-
-        forces, stress, rotational_grad = compute_gradient_forces_and_stress(
-            energy=interaction_energy,
-            positions=batch.node_features["positions"],
-            displacement=batch.system_features["stress_displacement"],
-            cell=batch.system_features["cell"],
-            training=self.training,
-            compute_stress=self.has_stress,
-            generator=batch.system_features["generator"],
+        out["interaction_energy"] = interaction_energy
+        out["energy"] = cast(EnergyHead, self.heads["energy"]).absolute_energy(
+            interaction_energy, batch, fp64_energy
         )
 
-        # Add explicit/spatial Coulomb force/stress corrections (see CoulombModule docstring).
-        if self.coulomb_module is not None:
-            assert coulomb_explicit_forces is not None, "Explicit/spatial forces are not computed"
-            assert coulomb_explicit_virial is not None, "Explicit/spatial virial is not computed"
-            forces = forces + coulomb_explicit_forces
-            if self.has_stress:
-                assert stress is not None, "has_stress is True but stress is None"
-                cell_3d = batch.system_features["cell"].view(-1, 3, 3)
-                volume = torch.linalg.det(cell_3d).abs()
-                coulomb_stress_3x3 = -coulomb_explicit_virial / volume.view(-1, 1, 1)
-                coulomb_stress_3x3 = torch.where(
-                    torch.abs(coulomb_stress_3x3) < 1e10,
-                    coulomb_stress_3x3,
-                    torch.zeros_like(coulomb_stress_3x3),
-                )
-                stress = stress + torch_full_3x3_to_voigt_6_stress(coulomb_stress_3x3)
+        if compute_forces or compute_stress:
+            forces, stress, rotational_grad = compute_gradient_forces_and_stress(
+                energy=interaction_energy,
+                positions=batch.node_features["positions"],
+                displacement=batch.system_features["stress_displacement"],
+                cell=batch.system_features["cell"],
+                training=self.training,
+                compute_stress=compute_stress,
+                generator=batch.system_features["generator"],
+            )
 
-        out[self.grad_forces_name] = forces  # eV / A
-        if self.has_stress:
-            out[self.grad_stress_name] = stress  # eV / A^3
+            if "analytic_forces" in out:
+                forces = forces + out["analytic_forces"]
+            if "analytic_stress" in out:
+                stress = stress + out["analytic_stress"]
 
-        out[self.grad_rotation_name] = rotational_grad
+            if compute_forces:
+                out["forces"] = forces  # eV / A
+            if compute_stress:
+                out["stress"] = stress  # eV / A^3
+            out["rotational_grad"] = rotational_grad
+
         for name in self.extra_properties:
             out[name] = self.heads[name](node_features, batch)
 
@@ -256,32 +262,45 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
         self,
         batch: AtomGraphs,
         split: bool = False,
+        *,
+        compute_forces: bool = True,
+        compute_stress: bool = True,
         fp64_energy: bool = True,
+        **kwargs,
     ) -> dict[str, torch.Tensor]:
-        """Predict energy, forces, and stress.
+        """Consumer-facing inference: absolute energy, forces, and stress.
 
         Args:
-            batch: Input batch.
-            split: If True, split predictions per graph.
-            fp64_energy: If True (default), return absolute energy in fp64;
+            batch: Input atomic graph batch.
+            split: If True, split per-system predictions into a list.
+            compute_forces: Include forces in the output.
+            compute_stress: Include stress in the output.
+            fp64_energy: Upcast energy to fp64 before adding reference;
                 required to preserve kJ/mol resolution since reference
-                energies can be as high as ~1e4-1e5 eV. If False, returns
-                energy in the input dtype.
-        """
-        preds = self(batch)
+                energies can be as high as ~1e4-1e5 eV.
 
-        out = {}
-        energy_head = cast(EnergyHead, self.heads[self.energy_name])
-        out[self.energy_name] = energy_head.absolute_energy(
-            preds[self.energy_name], batch, fp64=fp64_energy
+        If both compute_forces and compute_stress are False, the autograd computation
+        is skipped and the energy retains its computation graph.
+
+        Returns:
+            "energy"  — absolute energy (B,)
+            "forces"  — total forces (N, 3)
+            "stress"  — total stress in Voigt notation (B, 6)
+        """
+        # self() not self.forward() to respect torch.compile
+        preds = self(
+            batch,
+            compute_forces=compute_forces,
+            compute_stress=compute_stress,
+            fp64_energy=fp64_energy,
         )
-        out[self.grad_forces_name] = preds[self.grad_forces_name]
-        if self.has_stress:
-            assert self.grad_stress_name is not None, (
-                "grad_stress_name must be set if has_stress is True"
-            )
-            out[self.grad_stress_name] = preds[self.grad_stress_name]
-        out[self.grad_rotation_name] = preds[self.grad_rotation_name]
+
+        out: dict[str, torch.Tensor] = {"energy": preds["energy"]}
+        if compute_forces and "forces" in preds:
+            out["forces"] = preds["forces"]
+        if compute_stress and "stress" in preds:
+            out["stress"] = preds["stress"]
+
         for name in self.extra_properties:
             head = self.heads[name]
             if isinstance(head, ForcefieldHead):
@@ -301,96 +320,65 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
         """Compute loss including both direct and conservative terms."""
         out = self(batch)
 
-        energy_pred = out[self.energy_name]
-        raw_grad_forces_pred = out[self.grad_forces_name]
+        energy_pred = out["interaction_energy"]
+        forces_pred = out["forces"]
 
-        # metrics
         metrics: dict = {}
-
-        total_loss = torch.tensor(
-            0.0,
-            device=batch.positions.device,
-            dtype=batch.positions.dtype,
-        )
+        total_loss = torch.tensor(0.0, device=batch.positions.device, dtype=batch.positions.dtype)
 
         # Energy
-        energy_head = self.heads[self.energy_name]
-        energy_head = cast(EnergyHead, energy_head)
+        energy_head = cast(EnergyHead, self.heads["energy"])
         loss_out = energy_head.loss(energy_pred, batch)
-        loss = self.loss_weights[self.energy_name] * loss_out.loss
+        loss = self.loss_weights["energy"] * loss_out.loss
         total_loss += loss
         metrics.update(loss_out.log)
-        metrics[f"{self.energy_name}_loss"] = loss
+        metrics["energy_loss"] = loss
 
         # Conservative forces
         loss_out = forces_loss_function(
-            raw_pred=raw_grad_forces_pred,
-            raw_target=batch.node_targets[self.forces_name],
-            raw_gold_target=batch.node_targets[self.forces_name],
-            name=self.forces_name,
+            raw_pred=forces_pred,
+            raw_target=batch.node_targets["forces"],
+            raw_gold_target=batch.node_targets["forces"],
+            name="forces",
             normalizer=self.grad_forces_normalizer,
             n_node=batch.n_node,
             fix_atoms=batch.fix_atoms,
             loss_type=self.forces_loss_type,
             training=self.training,
         )
-        loss = self.loss_weights[self.grad_forces_name] * loss_out.loss
+        loss = self.loss_weights["forces"] * loss_out.loss
         total_loss += loss
-        metrics.update({f"{self.grad_prefix}-{k}": v for k, v in loss_out.log.items()})
-        metrics[f"{self.grad_forces_name}_loss"] = loss
+        metrics.update(loss_out.log)
+        metrics["forces_loss"] = loss
 
         # Conservative stress (optional)
-        if self.has_stress and self.grad_stress_name in out:
-            assert self.stress_name is not None, "stress_name must be set if has_stress is True"
-            assert self.grad_stress_name is not None, (
-                "grad_stress_name must be set if has_stress is True"
-            )
-            raw_grad_stress_pred = out[self.grad_stress_name]
+        if self.has_stress and "stress" in out:
             loss_out = stress_loss_function(
-                raw_pred=raw_grad_stress_pred,
-                raw_target=batch.system_targets[self.stress_name],
-                raw_gold_target=batch.system_targets[self.stress_name],
-                name=self.stress_name,
+                raw_pred=out["stress"],
+                raw_target=batch.system_targets["stress"],
+                raw_gold_target=batch.system_targets["stress"],
+                name="stress",
                 normalizer=self.grad_stress_normalizer,
                 loss_type=energy_head.loss_type,
             )
-            loss = self.loss_weights[self.grad_stress_name] * loss_out.loss
-            loss_out.log[f"{self.grad_stress_name}_loss"] = loss
+            loss = self.loss_weights["stress"] * loss_out.loss
             total_loss += loss
-            metrics.update({f"{self.grad_prefix}-{k}": v for k, v in loss_out.log.items()})
-
-        # Direct forces / stress predictions
-        for grad_name in [self.grad_forces_name] + (
-            [self.grad_stress_name] if self.has_stress and self.grad_stress_name in out else []
-        ):
-            assert grad_name is not None
-            direct_name = grad_name.replace(self.grad_prefix + "_", "")
-            if direct_name in self.extra_properties:
-                direct_head = cast(ForcefieldHead, self.heads[direct_name])
-                direct_pred = out[direct_name]
-                loss_out = direct_head.loss(direct_pred, batch)
-                loss = self.loss_weights[direct_name] * loss_out.loss
-                total_loss += loss
-                metrics.update(loss_out.log)
-                metrics[f"{direct_name}_loss"] = loss
+            metrics.update(loss_out.log)
+            metrics["stress_loss"] = loss
 
         # Equigrad
-        if self.grad_rotation_name in self.loss_weights:
-            rotational_grad_rms = torch.linalg.norm(
-                out[self.grad_rotation_name],
-                dim=(1, 2),
-            ).mean()
-            loss = self.loss_weights[self.grad_rotation_name] * rotational_grad_rms
+        if "rotational_grad" in self.loss_weights:
+            rotational_grad_rms = torch.linalg.norm(out["rotational_grad"], dim=(1, 2)).mean()
+            loss = self.loss_weights["rotational_grad"] * rotational_grad_rms
             total_loss += loss
             metrics["equigrad_loss"] = loss
-            metrics[f"{self.grad_rotation_name}_rms"] = rotational_grad_rms
+            metrics["rotational_grad_rms"] = rotational_grad_rms
 
         # Confidence
         if "confidence" in self.heads:
-            confidence_head = self.heads["confidence"]
-            confidence_head = cast(ConfidenceHead, confidence_head)
-            raw_forces_target = batch.node_targets[self.forces_name]
-            forces_error = torch.abs(raw_grad_forces_pred - raw_forces_target).mean(dim=-1)
+            confidence_head = cast(ConfidenceHead, self.heads["confidence"])
+            raw_forces_target = batch.node_targets["forces"]
+            forces_error = torch.abs(forces_pred - raw_forces_target).mean(dim=-1)
             confidence_logits = out["confidence"]
             loss_out = confidence_head.loss(confidence_logits, forces_error, batch)
             loss = self.loss_weights["confidence"] * loss_out.loss

--- a/orb_models/forcefield/models/coulomb_module.py
+++ b/orb_models/forcefield/models/coulomb_module.py
@@ -10,6 +10,7 @@ from nvalchemiops.torch.interactions.electrostatics import (
 from orb_models.common.atoms.batch.graph_batch import AtomGraphs
 from orb_models.common.atoms.graph_featurization import _compute_neighbor_list_with_fallback
 from orb_models.common.models.segment_ops import aggregate_nodes, segment_sum
+from orb_models.forcefield.models.forcefield_utils import torch_full_3x3_to_voigt_6_stress
 
 COULOMB_CONSTANT = 14.3996  # eV*A/e^2
 
@@ -59,15 +60,19 @@ class CoulombModule(torch.nn.Module):
         latent_charges: torch.Tensor,
         batch: AtomGraphs,
         *,
+        compute_forces: bool = True,
+        compute_stress: bool = True,
         kwargs: dict[str, Any] = {},
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Compute per-system electrostatic energy, forces, and virial.
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+        """Compute per-system electrostatic energy, and optionally forces and stress.
 
         For non-periodic systems we use the direct Coulomb sum; for periodic systems we use Particle Mesh Ewald.
 
         Args:
             latent_charges: (n_atoms, 1) predicted charges (must require grad).
             batch: AtomGraphs batch (positions, cell, pbc read from here).
+            compute_forces: Whether to compute explicit spatial forces.
+            compute_stress: Whether to compute explicit spatial stress (Voigt-6).
             kwargs: Additional keyword arguments to _direct_coulomb and _particle_mesh_ewald. (Useful for testing.)
         """
         # Validate kwargs against accepted PME parameters.
@@ -95,10 +100,16 @@ class CoulombModule(torch.nn.Module):
         n_atoms = positions.shape[0]
 
         energy = torch.zeros(n_systems, device=positions.device, dtype=positions.dtype)
-        explicit_forces = torch.zeros(n_atoms, 3, device=positions.device, dtype=positions.dtype)
-        explicit_virial = torch.zeros(
-            n_systems, 3, 3, device=positions.device, dtype=positions.dtype
-        )
+        explicit_forces: torch.Tensor | None = None
+        explicit_virial: torch.Tensor | None = None
+        if compute_forces:
+            explicit_forces = torch.zeros(
+                n_atoms, 3, device=positions.device, dtype=positions.dtype
+            )
+        if compute_stress:
+            explicit_virial = torch.zeros(
+                n_systems, 3, 3, device=positions.device, dtype=positions.dtype
+            )
 
         # Non-periodic systems
         np_sys_idx = is_nonperiodic.nonzero(as_tuple=True)[0]
@@ -127,15 +138,36 @@ class CoulombModule(torch.nn.Module):
                 torch.arange(p_sys_idx.shape[0], device=batch_idx.device), p_n_node
             )
             p_energy, p_forces, p_virial = self._particle_mesh_ewald(
-                p_charges, p_positions, p_cell, p_batch_idx, p_sys_idx.shape[0], p_pbc, **pme_kwargs
+                p_charges,
+                p_positions,
+                p_cell,
+                p_batch_idx,
+                p_sys_idx.shape[0],
+                p_pbc,
+                compute_forces=compute_forces,
+                compute_virial=compute_stress,
+                **pme_kwargs,
             )
             energy[p_sys_idx] = p_energy
-            # Map periodic atom forces and virial back to full batch
-            p_atom_indices = p_atom_mask.nonzero(as_tuple=True)[0]
-            explicit_forces[p_atom_indices] = p_forces
-            explicit_virial[p_sys_idx] = p_virial
+            if compute_forces:
+                assert explicit_forces is not None
+                p_atom_indices = p_atom_mask.nonzero(as_tuple=True)[0]
+                explicit_forces[p_atom_indices] = p_forces
+            if compute_stress:
+                assert explicit_virial is not None
+                explicit_virial[p_sys_idx] = p_virial
 
-        return energy, explicit_forces, explicit_virial
+        explicit_stress: torch.Tensor | None = None
+        if explicit_virial is not None:
+            cell_3d = cell.view(-1, 3, 3)
+            volume = torch.linalg.det(cell_3d).abs()
+            stress_3x3 = -explicit_virial / volume.view(-1, 1, 1)
+            stress_3x3 = torch.where(
+                torch.abs(stress_3x3) < 1e10, stress_3x3, torch.zeros_like(stress_3x3)
+            )
+            explicit_stress = torch_full_3x3_to_voigt_6_stress(stress_3x3)
+
+        return energy, explicit_forces, explicit_stress
 
     def _direct_coulomb(
         self,
@@ -182,6 +214,8 @@ class CoulombModule(torch.nn.Module):
         n_systems: int,
         pbc: torch.Tensor,
         *,
+        compute_forces: bool = True,
+        compute_virial: bool = True,
         pme_cutoff: float | None = None,
         pme_alpha: float | None = None,
         pme_mesh_dimensions: tuple[int, ...] | None = None,
@@ -218,7 +252,7 @@ class CoulombModule(torch.nn.Module):
         # so E = k * sum(q_i*q_j/r) = sum(q_scaled_i * q_scaled_j / r).
         scaled_charges = charges * torch.sqrt(self.coulomb_constant)
 
-        per_atom_energies, explicit_forces, explicit_virial = _particle_mesh_ewald(
+        pme_result = _particle_mesh_ewald(
             positions=positions,
             charges=scaled_charges,
             cell=cell,
@@ -230,18 +264,24 @@ class CoulombModule(torch.nn.Module):
             neighbor_matrix_shifts=neighbor_shift_matrix.to(torch.int32),
             mask_value=positions.shape[0],
             accuracy=self.pme_accuracy,
-            compute_forces=True,
+            compute_forces=compute_forces,
             compute_charge_gradients=False,
-            compute_virial=True,
+            compute_virial=compute_virial,
             hybrid_forces=pme_hybrid_forces,
         )
+        # PME returns a variable-length tuple: energies, [forces], [virial].
+        pme_outputs = pme_result if isinstance(pme_result, tuple) else (pme_result,)
+        it = iter(pme_outputs)
+        per_atom_energies = next(it)
+        explicit_forces = (
+            next(it).detach().to(positions.dtype) if compute_forces else torch.zeros_like(positions)
+        )
+        explicit_virial = (
+            next(it).detach().to(positions.dtype)
+            if compute_virial
+            else torch.zeros(n_systems, 3, 3, device=positions.device, dtype=positions.dtype)
+        )
         per_atom_energies = per_atom_energies.to(positions.dtype)
-        # Explicit forces/virial should not be differentiated (the contribution from the charges
-        # is included in the energy gradient with hybrid_forces=True using the straight-through trick).
-        # There's currently a bug in nvalchemiops where virials remain connected to the graph,
-        # so we detach them here for now.
-        explicit_forces = explicit_forces.detach().to(positions.dtype)
-        explicit_virial = explicit_virial.detach().to(positions.dtype)
 
         # Per-system energy
         energies = segment_sum(per_atom_energies, batch_idx, n_systems)

--- a/orb_models/forcefield/models/direct_regressor.py
+++ b/orb_models/forcefield/models/direct_regressor.py
@@ -96,63 +96,122 @@ class DirectForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
         """Disable stress computation."""
         self._stress_disabled = True
 
-    def forward(self, batch: AtomGraphs) -> dict[str, torch.Tensor | dict[str, torch.Tensor]]:
-        """Forward pass of DirectForcefieldRegressor."""
+    @property
+    def properties(self) -> list[str]:
+        """Canonical names of properties available from predict()."""
+        heads = list(self.heads.keys())
+        if self._stress_disabled:
+            heads = [head for head in heads if "stress" not in head]
+        if "energy" in heads:
+            heads.append("free_energy")
+        return heads
+
+    @property
+    def autograd_derivative_keys(self) -> frozenset[str]:
+        """Derivative keys computed via autograd on the energy.
+
+        Direct models predict forces/stress from NN heads, not via
+        autograd, so this is always empty.
+        """
+        return frozenset()
+
+    @property
+    def analytic_derivative_keys(self) -> frozenset[str]:
+        """Forward() output keys for spatial derivatives that cannot be computed via autograd.
+
+        Direct models predict forces/stress from NN heads, so there are
+        no explicit (analytical) derivative terms to expose.
+        """
+        return frozenset()
+
+    def forward(
+        self,
+        batch: AtomGraphs,
+        *,
+        compute_forces: bool = True,
+        compute_stress: bool = True,
+        fp64_energy: bool = True,
+    ) -> dict[str, torch.Tensor]:
+        """Compute absolute energy and NN-predicted forces/stress.
+
+        Returns a dict with total quantities and their components:
+
+            Totals (consumer-facing):
+                "energy"              — absolute energy (B,); fp64 when fp64_energy=True
+                "forces"              — NN-predicted forces (N, 3)
+                "stress"              — NN-predicted stress (B, 6) in Voigt notation
+
+            Components (used by loss and pipeline frameworks):
+                "interaction_energy"  — energy without reference (B,)
+        """
+        compute_stress = compute_stress and not self._stress_disabled and self.has_stress
         out = self.model(batch)
         node_features = out["node_features"]
         for name, head in self.heads.items():
-            if self._stress_disabled and "stress" in name:
+            if not compute_forces and "forces" in name:
                 continue
-            res = head(node_features, batch)
-            out[name] = res
+            if not compute_stress and "stress" in name:
+                continue
+            out[name] = head(node_features, batch)
 
         if self.pair_repulsion:
             out_pair_repulsion = self.pair_repulsion_fn(batch)
-            for name, head in self.heads.items():
-                if self._stress_disabled and "stress" in name:
+            for name in self.heads:
+                if name not in out:
                     continue
                 raw_repulsion = self._get_raw_repulsion(name, out_pair_repulsion)
                 if raw_repulsion is not None:
                     out[name] = out[name] + raw_repulsion
+
+        if "energy" in self.heads and isinstance(self.heads["energy"], EnergyHead):
+            interaction_energy = out["energy"]
+            out["interaction_energy"] = interaction_energy
+            out["energy"] = cast(EnergyHead, self.heads["energy"]).absolute_energy(
+                interaction_energy, batch, fp64_energy
+            )
+
         return out
 
     def predict(
         self,
         batch: AtomGraphs,
         split: bool = False,
+        *,
+        compute_forces: bool = True,
+        compute_stress: bool = True,
         fp64_energy: bool = True,
+        **kwargs,
     ) -> dict[str, torch.Tensor]:
-        """Predict node and/or graph level attributes.
+        """Consumer-facing inference: absolute energy, total forces/stress.
 
         Args:
-            batch: Input batch.
-            split: If True, split predictions per graph.
-            fp64_energy: If True (default), return absolute energy in fp64;
+            batch: Input atomic graph batch.
+            split: If True, split per-system predictions into a list.
+            compute_forces: Include forces in the output.
+            compute_stress: Include stress in the output.
+            fp64_energy: Upcast energy to fp64 before adding reference;
                 required to preserve kJ/mol resolution since reference
-                energies can be as high as ~1e4-1e5 eV. If False, returns
-                energy in the input dtype.
-        """
-        out = self.model(batch)
-        node_features = out["node_features"]
-        output = {}
-        for name, head in self.heads.items():
-            if self._stress_disabled and "stress" in name:
-                continue
-            if isinstance(head, EnergyHead):
-                output[name] = head.predict(node_features, batch, fp64=fp64_energy)
-            else:
-                output[name] = cast(ForcefieldHead | ConfidenceHead, head).predict(
-                    node_features, batch
-                )
+                energies can be as high as ~1e4-1e5 eV.
 
-        if self.pair_repulsion:
-            out_pair_repulsion = self.pair_repulsion_fn(batch)
-            for name, head in self.heads.items():
-                if self._stress_disabled and "stress" in name:
-                    continue
-                raw_repulsion = self._get_raw_repulsion(name, out_pair_repulsion)
-                if raw_repulsion is not None:
-                    output[name] = output[name] + raw_repulsion
+        Returns:
+            "energy"  — absolute energy in fp64 (B,)
+            "forces"  — NN-predicted forces (N, 3)
+            "stress"  — NN-predicted stress in Voigt notation (B, 6)
+        """
+        # self() not self.forward() to respect torch.compile
+        preds = self(
+            batch,
+            compute_forces=compute_forces,
+            compute_stress=compute_stress,
+            fp64_energy=fp64_energy,
+        )
+
+        output = {name: preds[name] for name in self.heads if name in preds}
+        for name, head in self.heads.items():
+            if name not in preds:
+                continue
+            if isinstance(head, ConfidenceHead):
+                output[name] = torch.softmax(preds[name], dim=-1)
 
         if split:
             for name, pred in output.items():
@@ -177,7 +236,8 @@ class DirectForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
             if self._stress_disabled and "stress" in name:
                 continue
             head = cast(ForcefieldHead, head)
-            head_out = head.loss(out[name], batch)
+            pred = out["interaction_energy"] if name == "energy" else out[name]
+            head_out = head.loss(pred, batch)
             weight = self.loss_weights[name]
             loss = weight * head_out.loss
             total_loss += loss
@@ -223,16 +283,6 @@ class DirectForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
             assign=assign,
             skip_artifact_reference_energy=skip_artifact_reference_energy,
         )
-
-    @property
-    def properties(self):
-        """List of names of predicted properties."""
-        heads = list(self.heads.keys())
-        if self._stress_disabled:
-            heads = [head for head in heads if "stress" not in head]
-        if "energy" in heads:
-            heads.append("free_energy")
-        return heads
 
     def is_compiled(self):
         """Check if the model is compiled."""

--- a/orb_models/forcefield/models/forcefield_utils.py
+++ b/orb_models/forcefield/models/forcefield_utils.py
@@ -197,7 +197,11 @@ def compute_gradient_forces_and_stress(
         allow_unused=True,
     )
     forces = grads[0]
-    virials = grads[1]
+    # neg_virials = dE/dε (the negative of the Clausius/MD-textbook virial
+    # W = −Σᵢ rᵢ · Fᵢ = +Σᵢ rᵢ · ∂E/∂rᵢ = +dE/dε; so `neg_virials = -W`).
+    # We keep this sign because stress = dE/dε / V (elasticity / ASE Voigt
+    # convention, tensile positive).
+    neg_virials = grads[1]
     rotational_grad = grads[2]
 
     if forces is None:
@@ -206,9 +210,9 @@ def compute_gradient_forces_and_stress(
             "positions has been broken. Make sure the positions tensor has "
             "not been replaced since calling compute_differentiable_edge_vectors()"
         )
-    if virials is None:
+    if neg_virials is None:
         raise ValueError(
-            "Virials are None. The computational graph between energy and "
+            "neg_virials are None. The computational graph between energy and "
             "displacement has been broken. Make sure the displacement tensor has "
             "not been replaced since calling compute_differentiable_edge_vectors()"
         )
@@ -223,7 +227,7 @@ def compute_gradient_forces_and_stress(
     if compute_stress:
         cell = cell.view(-1, 3, 3)
         volume = torch.linalg.det(cell).abs().unsqueeze(-1)
-        stress = virials / volume.view(-1, 1, 1)
+        stress = neg_virials / volume.view(-1, 1, 1)
         stress = torch.where(torch.abs(stress) < 1e10, stress, torch.zeros_like(stress))
     voigt_stress = torch_full_3x3_to_voigt_6_stress(stress)
     return -1 * forces, voigt_stress, rotational_grad

--- a/orb_models/forcefield/models/pair_repulsion.py
+++ b/orb_models/forcefield/models/pair_repulsion.py
@@ -23,7 +23,7 @@ class ZBLBasis(torch.nn.Module):
     def __init__(
         self,
         p: int = 6,
-        node_aggregation: str = "mean",
+        node_aggregation: str = "sum",
         compute_gradients: bool = False,
     ):
         super().__init__()

--- a/orb_models/forcefield/pretrained.py
+++ b/orb_models/forcefield/pretrained.py
@@ -100,7 +100,7 @@ def load_model(
         train: Whether to set the model to training mode and keep parameters trainable (except reference energies).
         train_reference_energies: Whether to make reference energies trainable during finetuning.
         loss_weights: Optional dictionary of loss weights to override model defaults.
-            Keys should match the loss terms (e.g., "energy", "grad_forces", "forces", "stress", "grad_stress").
+            Keys should match the loss terms (e.g., "energy", "forces", "stress").
 
     Returns:
         model: The pretrained model
@@ -428,7 +428,7 @@ def orbmol_v2(
     # Default to evenly weighted losses
     loss_weights = {
         "energy": 1.0,
-        "grad_forces": 1.0,
+        "forces": 1.0,
         "confidence": 1.0,
         **(loss_weights or {}),
     }
@@ -484,7 +484,7 @@ def orb_v3_conservative_omol(
     # Default to evenly weighted losses
     loss_weights = {
         "energy": 1.0,
-        "grad_forces": 1.0,
+        "forces": 1.0,
         "confidence": 1.0,
         **(loss_weights or {}),
     }
@@ -590,8 +590,8 @@ def orb_v3_conservative_20_omat(
     # Default to evenly weighted losses
     loss_weights = {
         "energy": 1.0,
-        "grad_forces": 1.0,
-        "grad_stress": 1.0,
+        "forces": 1.0,
+        "stress": 1.0,
         "confidence": 1.0,
         **(loss_weights or {}),
     }
@@ -642,8 +642,8 @@ def orb_v3_conservative_inf_omat(
     # Default to evenly weighted losses
     loss_weights = {
         "energy": 1.0,
-        "grad_forces": 1.0,
-        "grad_stress": 1.0,
+        "forces": 1.0,
+        "stress": 1.0,
         "confidence": 1.0,
         **(loss_weights or {}),
     }
@@ -774,8 +774,8 @@ def orb_v3_conservative_20_mpa(
     # Default to evenly weighted losses
     loss_weights = {
         "energy": 1.0,
-        "grad_forces": 1.0,
-        "grad_stress": 1.0,
+        "forces": 1.0,
+        "stress": 1.0,
         "confidence": 1.0,
         **(loss_weights or {}),
     }
@@ -826,8 +826,8 @@ def orb_v3_conservative_inf_mpa(
     # Default to evenly weighted losses
     loss_weights = {
         "energy": 1.0,
-        "grad_forces": 1.0,
-        "grad_stress": 1.0,
+        "forces": 1.0,
+        "stress": 1.0,
         "confidence": 1.0,
         **(loss_weights or {}),
     }

--- a/tests/common/atoms/test_pbc_radius_graph.py
+++ b/tests/common/atoms/test_pbc_radius_graph.py
@@ -146,7 +146,7 @@ def test_CO2_graph(edge_method):
     adsorbate = get_CO2()
     positions = torch.tensor(adsorbate.positions, dtype=torch.float32)
     cell = torch.zeros((3, 3), dtype=torch.float32)
-    pbc = torch.tensor([False], dtype=torch.bool)
+    pbc = torch.tensor([False, False, False], dtype=torch.bool)
     out = graph_featurization.compute_pbc_radius_graph(
         positions=positions,
         radius=6.0,

--- a/tests/expensive_tests/conftest.py
+++ b/tests/expensive_tests/conftest.py
@@ -22,7 +22,7 @@ def orb_v3_conservative_omat_and_config():
     """Load the orb model and system configuration."""
     model, sys_cfg = pretrained.orb_v3_conservative_inf_omat()
     model.loss_weights["rotational_grad"] = 1.0
-    model.loss_weights["grad_stress"] = 1.0
+    model.loss_weights["stress"] = 1.0
     return model, sys_cfg
 
 
@@ -31,7 +31,7 @@ def orb_v3_conservative_omol_and_config():
     """Load the orb model and system configuration."""
     model, sys_cfg = pretrained.orb_v3_conservative_omol()
     model.loss_weights["rotational_grad"] = 1.0
-    model.loss_weights["grad_stress"] = 1.0
+    model.loss_weights["stress"] = 1.0
     return model, sys_cfg
 
 
@@ -40,5 +40,5 @@ def orbmol_v2_and_config():
     """Load the orbmol-v2 model with learnable electrostatics."""
     model, sys_cfg = pretrained.orbmol_v2()
     model.loss_weights["rotational_grad"] = 1.0
-    model.loss_weights["grad_stress"] = 1.0
+    model.loss_weights["stress"] = 1.0
     return model, sys_cfg

--- a/tests/expensive_tests/test_backwards_compatibility.py
+++ b/tests/expensive_tests/test_backwards_compatibility.py
@@ -86,8 +86,8 @@ def test_orb_v3_con_omat_predictions(orb_v3_conservative_omat_and_config):
     graph = adapter.from_ase_atoms(atoms)
     result = orb.predict(graph)
     energy = result["energy"][0].detach().numpy()
-    forces = result["grad_forces"][0].detach().numpy()
-    stress = result["grad_stress"][0].detach().numpy()
+    forces = result["forces"][0].detach().numpy()
+    stress = result["stress"][0].detach().numpy()
     energy_gold = np.array(-14.9525)
     forces_gold = np.array([1.3970e-09, 1.0419e-08, -1.0361e-08])
     stress_gold = np.array(
@@ -128,7 +128,7 @@ def test_orbmol_v1_con_predictions(orb_v3_conservative_omol_and_config):
     graph = adapter.from_ase_atoms(atoms)
     result = orb.predict(graph)
     energy = result["energy"][0].detach().numpy()
-    forces = result["grad_forces"][0].detach().numpy()
+    forces = result["forces"][0].detach().numpy()
     assert np.isclose(energy, energy_gold, atol=1e-5)
     np.testing.assert_allclose(forces, forces_gold, atol=1e-5)
 
@@ -180,7 +180,7 @@ def test_pre_cutoff_conservative_models_use_mean_pair_repulsion(fixture_name, re
     The default for newly-trained ConservativeForcefieldRegressor is
     node_aggregation="sum"; load_model switches it back to "mean" for
     artifacts created before _CONSERVATIVE_PAIR_REPULSION_SUM_CUTOFF. All
-    shipped orb-v3 conservative models (and orbmol-v2) predate that cutoff.
+    shipped orb-v3 conservative models predate that cutoff.
     """
     orb, _ = request.getfixturevalue(fixture_name)
     assert orb.pair_repulsion, f"{fixture_name} should have pair_repulsion enabled"
@@ -201,7 +201,7 @@ def test_orbmol_v2_predictions(orbmol_v2_and_config):
     graph = adapter.from_ase_atoms(atoms)
     result = orb.predict(graph)
     energy = result["energy"][0].detach().numpy()
-    forces = result["grad_forces"][0].detach().numpy()
+    forces = result["forces"][0].detach().numpy()
     h2o_energy_gold = np.array(-2079.86222)
     h2o_forces_gold = np.array([4.6290e-04, 6.6572e-04, -4.8360e-01])
     assert np.isclose(energy, h2o_energy_gold, atol=1e-5)
@@ -214,7 +214,7 @@ def test_orbmol_v2_predictions(orbmol_v2_and_config):
     graph = adapter.from_ase_atoms(atoms)
     result = orb.predict(graph)
     energy = result["energy"][0].detach().numpy()
-    stress = result["grad_stress"][0].detach().numpy()
+    stress = result["stress"][0].detach().numpy()
     cu_energy_gold = np.array(-178550.98098)
     cu_stress_gold = np.array([-0.09994, -0.10850, -0.11481, -0.00028, -0.00035, 0.00305])
     assert np.isclose(energy, cu_energy_gold, atol=1e-5)

--- a/tests/forcefield/conftest.py
+++ b/tests/forcefield/conftest.py
@@ -101,7 +101,7 @@ class EuclideanNormModel(torch.nn.Module):
         )
         return energies, neg_grad, stress
 
-    def predict(self, batch, split: bool = False):
+    def predict(self, batch, split: bool = False, **kwargs):
         assert not split, "Split not supported for EuclideanNormModel."
         energy, forces, stress = self.forward(batch)
         return {"energy": energy, "forces": forces, "stress": stress}
@@ -223,8 +223,8 @@ def conservative_regressor(gns_model, energy_head, latent_charge_head, coulomb_m
         model=gns_model,
         loss_weights={
             "energy": 1.0,
-            "grad_forces": 1.0,
-            "grad_stress": 1.0,
+            "forces": 1.0,
+            "stress": 1.0,
             "rotational_grad": 1.0,
         },
         coulomb_module=coulomb_module,

--- a/tests/forcefield/test_calculator.py
+++ b/tests/forcefield/test_calculator.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from orb_models.forcefield.forcefield_adapter import ForcefieldAtomsAdapter
 from orb_models.forcefield.inference.calculator import ORBCalculator
 
@@ -12,40 +10,13 @@ def test_conservative_calculator(conservative_regressor, mptraj_10_systems_db):
     )
     conservative_calc.calculate(atoms)
 
-    # Test that setting 'conservative=True' correctly relabels the keys in the results dict.
-    assert np.allclose(
-        conservative_calc.results["forces"],
-        conservative_calc.results[conservative_calc.model.grad_forces_name],
-    )
-    assert np.allclose(
-        conservative_calc.results["stress"],
-        conservative_calc.results[conservative_calc.model.grad_stress_name],
-    )
-
-
-def test_calc_conservative_defaults(conservative_regressor):
-    # Conservative model should use conservative forces by default
-    calc = ORBCalculator(
-        model=conservative_regressor,
-        atoms_adapter=ForcefieldAtomsAdapter(6.0, 20),
-    )
-    assert calc.conservative is True
-    assert set(calc.implemented_properties) == set(
-        [
-            "energy",
-            "free_energy",
-            "forces",
-            "stress",
-            "grad_forces",
-            "grad_stress",
-            "rotational_grad",
-        ]
-    )
+    assert "energy" in conservative_calc.results
+    assert "forces" in conservative_calc.results
+    assert "stress" in conservative_calc.results
 
 
 def test_calc_non_conservative_defaults(direct_regressor):
     calc = ORBCalculator(model=direct_regressor, atoms_adapter=ForcefieldAtomsAdapter(6.0, 20))
-    assert calc.conservative is False
     assert set(calc.implemented_properties) == {
         "energy",
         "free_energy",

--- a/tests/forcefield/test_conservative.py
+++ b/tests/forcefield/test_conservative.py
@@ -14,33 +14,40 @@ def test_regressor_forward(request, conservative_regressor, graph_name):
     graph = request.getfixturevalue(graph_name)
     out = conservative_regressor(graph)
     assert "energy" in out
-    assert "grad_forces" in out
-    assert "grad_stress" in out
+    assert "forces" in out
+    assert "stress" in out
 
 
 def test_regressor_loss(conservative_regressor, batch):
     out = conservative_regressor.loss(batch)
     out.loss.backward()
 
-    # Check that metrics are computed for both direct and conservative predictions
     assert any("energy" in k for k in out.log)
-    assert any("grad-forces" in k for k in out.log)
-    assert any("grad-stress" in k for k in out.log)
+    assert any("forces" in k for k in out.log)
+    assert any("stress" in k for k in out.log)
     assert any("rotational_grad" in k for k in out.log)
 
 
-def test_regressor_head_config_raises_error(gns_model, energy_head, force_head, stress_head):
+def test_regressor_head_config_raises_error(gns_model, energy_head):
     with pytest.raises(ValueError, match="Loss weights for unknown targets"):
         ConservativeForcefieldRegressor(
-            heads={"energy": energy_head, "forces": force_head},
+            heads={"energy": energy_head},
             model=gns_model,
             loss_weights={
                 "energy": 1.0,
                 "forces": 1.0,
                 "stress": 1.0,
-                "grad_forces": 1.0,
-                "grad_stress": 1.0,
+                "nonexistent_head": 1.0,
             },
+        )
+
+
+def test_forces_stress_heads_rejected(gns_model, energy_head, force_head, stress_head):
+    with pytest.raises(AssertionError, match="collide with gradient-based prediction keys"):
+        ConservativeForcefieldRegressor(
+            heads={"energy": energy_head, "forces": force_head, "stress": stress_head},
+            model=gns_model,
+            loss_weights={"energy": 1.0, "forces": 1.0, "stress": 1.0},
         )
 
 
@@ -68,8 +75,33 @@ def test_regressor_predict(batch, conservative_regressor):
     conservative_regressor.eval()
     inference = conservative_regressor.predict(batch)
     assert "energy" in inference
-    assert "grad_forces" in inference
-    assert "grad_stress" in inference
+    assert "forces" in inference
+    assert "stress" in inference
+
+
+def test_regressor_predict_preserves_kjmol_at_scale(batch, conservative_regressor):
+    """End-to-end mirror of test_energy_head_absolute_energy_preserves_kjmol_at_scale."""
+    conservative_regressor.eval()
+    large_ref = 1e5
+
+    energy_head = conservative_regressor.heads["energy"]
+    n_atoms = int(batch.n_node[0].item())
+    assert (batch.n_node == n_atoms).all(), "fixture assumption: uniform atom count"
+    with torch.no_grad():
+        energy_head.reference.linear.weight.fill_(large_ref / n_atoms)
+
+    # The MLP-produced interaction energy is whatever gets added to reference inside predict
+    interaction_energy = conservative_regressor(batch)["interaction_energy"].detach()
+
+    # fp64 path preserves the interaction energy against the large reference.
+    absolute = conservative_regressor.predict(batch, fp64_energy=True)["energy"]
+    recovered = (absolute - large_ref).float()
+    torch.testing.assert_close(recovered, interaction_energy, atol=1e-6, rtol=0)
+
+    # fp32 path loses the interaction energy precision, demonstrating why fp64 is required
+    absolute_fp32 = conservative_regressor.predict(batch, fp64_energy=False)["energy"]
+    fp32_roundtrip = absolute_fp32 - large_ref
+    assert not torch.allclose(fp32_roundtrip, interaction_energy, atol=1e-6, rtol=0)
 
 
 def test_featurization_differentiability_with_conservative_regressor(

--- a/tests/forcefield/test_coulomb_module.py
+++ b/tests/forcefield/test_coulomb_module.py
@@ -1,0 +1,1032 @@
+import ase
+import pytest
+import torch
+from nvalchemiops.torch.interactions.electrostatics import estimate_pme_parameters
+
+from orb_models.common.atoms.batch.graph_batch import AtomGraphs
+from orb_models.common.atoms.featurization import rotation_from_generator
+from orb_models.forcefield.forcefield_adapter import ForcefieldAtomsAdapter
+from orb_models.forcefield.models.coulomb_module import (
+    CoulombModule,
+    _fully_connected_senders_receivers,
+)
+from orb_models.forcefield.models.forcefield_utils import torch_full_3x3_to_voigt_6_stress
+
+
+def _get_coulomb_module() -> CoulombModule:
+    coulomb = CoulombModule(pme_accuracy=1e-6)
+    coulomb.eval()
+    return coulomb
+
+
+def _make_batch(atoms_list: list[ase.Atoms]) -> AtomGraphs:
+    adapter = ForcefieldAtomsAdapter(radius=6.0, max_num_neighbors=20)
+    return AtomGraphs.batch([adapter.from_ase_atoms(a) for a in atoms_list])
+
+
+def _water_molecules() -> list[ase.Atoms]:
+    return [
+        ase.Atoms(
+            "H2O",
+            positions=[[0, 0, 0], [0.96, 0, 0], [0.24, 0.93, 0]],
+            cell=[10, 10, 10],
+            pbc=True,
+        ),
+        ase.Atoms(
+            "H2O",
+            positions=[[1, 1, 1], [1.96, 1, 1], [1.24, 1.93, 1]],
+            cell=[10, 10, 10],
+            pbc=True,
+        ),
+    ]
+
+
+def _nonperiodic_molecules() -> list[ase.Atoms]:
+    return [
+        ase.Atoms("H2O", positions=[[0, 0, 0], [0.96, 0, 0], [0.24, 0.93, 0]]),
+        ase.Atoms("H2", positions=[[0, 0, 0], [0.74, 0, 0]]),
+    ]
+
+
+def _make_charge_fn(n_atoms: int, seed: int = 42) -> torch.nn.Module:
+    """Differentiable charge model that mixes all positions: q = W @ flatten(r).
+
+    Each charge depends on all atom positions (not just its own), which better
+    tests cross-atom gradient flow (dq_i/dr_j for i != j).
+    """
+    torch.manual_seed(seed)
+    return torch.nn.Sequential(
+        torch.nn.Flatten(),
+        torch.nn.Linear(3 * n_atoms, n_atoms, bias=False),
+        torch.nn.Unflatten(1, (n_atoms, 1)),
+    )
+
+
+def _total_forces(
+    energy: torch.Tensor,
+    explicit_forces: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    """Compute total Coulomb forces = explicit + autograd(-dE/dr)."""
+    (autograd_forces,) = torch.autograd.grad(energy.sum(), positions, create_graph=True)
+    return explicit_forces - autograd_forces
+
+
+def _virial_to_stress(virial: torch.Tensor, cell: torch.Tensor) -> torch.Tensor:
+    """Convert 3x3 virial to Voigt-6 stress: stress = -virial / volume."""
+    volume = torch.linalg.det(cell.view(-1, 3, 3)).abs()
+    stress_3x3 = -virial / volume.view(-1, 1, 1)
+    return torch_full_3x3_to_voigt_6_stress(stress_3x3)
+
+
+def _total_stress(
+    energy: torch.Tensor,
+    explicit_stress: torch.Tensor,
+    strain: torch.Tensor,
+    cell: torch.Tensor,
+) -> torch.Tensor:
+    """Compute total Coulomb stress = explicit + autograd component."""
+    (autograd_virial,) = torch.autograd.grad(energy.sum(), strain, create_graph=True)
+    autograd_stress = _virial_to_stress(autograd_virial.unsqueeze(0), cell).squeeze(0)
+    return explicit_stress.squeeze(0) - autograd_stress
+
+
+def _total_forces_and_stress(
+    energy: torch.Tensor,
+    explicit_forces: torch.Tensor,
+    explicit_stress: torch.Tensor,
+    positions: torch.Tensor,
+    strain: torch.Tensor,
+    cell: torch.Tensor,
+    training: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    (autograd_forces, autograd_virial) = torch.autograd.grad(
+        outputs=[energy.sum()],
+        inputs=[positions, strain],
+        create_graph=training,
+        retain_graph=training,
+    )
+    autograd_stress = _virial_to_stress(autograd_virial.unsqueeze(0), cell).squeeze(0)
+    return explicit_forces + autograd_forces, explicit_stress.squeeze(0) + autograd_stress
+
+
+def _apply_strain(
+    positions: torch.Tensor,
+    cell: torch.Tensor,
+    strain: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply strain deformation: pos' = pos @ (I+ε)^T, cell' = cell @ (I+ε)^T."""
+    deformation = torch.eye(3, dtype=strain.dtype, device=strain.device) + strain
+    strained_positions = positions @ deformation.T
+    strained_cell = (cell.squeeze(0) @ deformation.T).unsqueeze(0)
+    return strained_positions, strained_cell
+
+
+def _fd_forces(
+    energy_fn,
+    positions: torch.Tensor,
+    delta: float = 1e-6,
+) -> torch.Tensor:
+    """Central finite-difference forces: F_i = -(E(r+d) - E(r-d)) / 2d."""
+    forces = torch.zeros_like(positions)
+    pos_base = positions.detach().clone()
+    for i in range(pos_base.shape[0]):
+        for j in range(3):
+            pos_p = pos_base.clone()
+            pos_p[i, j] += delta
+            e_p = energy_fn(pos_p)
+
+            pos_m = pos_base.clone()
+            pos_m[i, j] -= delta
+            e_m = energy_fn(pos_m)
+
+            forces[i, j] = -(e_p - e_m) / (2 * delta)
+    return forces
+
+
+def _fd_virial(
+    energy_fn,
+    positions: torch.Tensor,
+    cell: torch.Tensor,
+    delta: float = 1e-6,
+) -> torch.Tensor:
+    """Central finite-difference virial: V_ij = -dE/dε_ij.
+
+    Applies a uniform strain ε to both cell and Cartesian positions
+    (preserving fractional coordinates) and numerically differentiates.
+    """
+    pos_base = positions.detach().clone()
+    cell_base = cell.detach().clone()
+    virial = torch.zeros(3, 3, dtype=positions.dtype, device=positions.device)
+
+    for i in range(3):
+        for j in range(3):
+            eps = torch.zeros(3, 3, dtype=positions.dtype, device=positions.device)
+            eps[i, j] = delta
+            pos_p, cell_p = _apply_strain(pos_base, cell_base, eps)
+            e_p = energy_fn(pos_p, cell_p)
+
+            pos_m, cell_m = _apply_strain(pos_base, cell_base, -eps)
+            e_m = energy_fn(pos_m, cell_m)
+
+            virial[i, j] = -(e_p - e_m) / (2 * delta)
+    return virial.unsqueeze(0)  # (1, 3, 3)
+
+
+def _fd_stress(
+    energy_fn,
+    positions: torch.Tensor,
+    cell: torch.Tensor,
+    delta: float = 1e-6,
+) -> torch.Tensor:
+    """Central finite-difference stress in Voigt-6 notation."""
+    virial = _fd_virial(energy_fn, positions, cell, delta)
+    return _virial_to_stress(virial, cell).squeeze(0)
+
+
+class TestNonPeriodic:
+    """Direct Coulomb sum for non-periodic systems."""
+
+    def test_shapes_and_finiteness(self):
+        batch = _make_batch(_nonperiodic_molecules())
+        n_atoms = batch.node_features["positions"].shape[0]
+        charges = torch.randn(n_atoms, 1)
+
+        coulomb = CoulombModule(direct_coulomb_erf_damping_sigma=1.0)
+        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
+
+        assert energy.shape == (2,)
+        assert torch.isfinite(energy).all()
+        assert energy.abs().sum() > 0
+        assert explicit_forces.shape == (n_atoms, 3)
+        assert explicit_stress.shape == (2, 6)
+
+    def test_zero_charges_zero_energy(self):
+        batch = _make_batch(_nonperiodic_molecules())
+        n_atoms = batch.node_features["positions"].shape[0]
+        charges = torch.zeros(n_atoms, 1)
+
+        coulomb = CoulombModule(direct_coulomb_erf_damping_sigma=1.0)
+        energy, _, _ = coulomb(charges, batch)
+
+        assert (energy.abs() < 1e-10).all()
+
+    def test_opposite_charges_attract(self):
+        atoms = ase.Atoms("H2", positions=[[0, 0, 0], [1, 0, 0]])
+        batch = _make_batch([atoms])
+        charges = torch.tensor([[1.0], [-1.0]])
+
+        coulomb = CoulombModule(direct_coulomb_erf_damping_sigma=1.0)
+        energy, _, _ = coulomb(charges, batch)
+
+        assert energy.item() < 0, "Opposite charges should attract (negative energy)"
+
+    def test_dEdq_nonzero(self):
+        batch = _make_batch(_nonperiodic_molecules())
+        n_atoms = batch.node_features["positions"].shape[0]
+        charges = torch.randn(n_atoms, 1, requires_grad=True)
+
+        coulomb = CoulombModule(direct_coulomb_erf_damping_sigma=1.0)
+        energy, _, _ = coulomb(charges, batch)
+
+        grad = torch.autograd.grad(energy.sum(), charges)[0]
+        assert grad is not None
+        assert grad.abs().sum() > 0
+
+    def test_forces_differentiable_wrt_charges(self):
+        """Total forces are differentiable w.r.t. charge model parameters."""
+        atoms = ase.Atoms("H2O", positions=[[0, 0, 0], [0.96, 0, 0], [0.24, 0.93, 0]])
+        batch = _make_batch([atoms])
+        charge_fn = _make_charge_fn(n_atoms=3)
+        coulomb = CoulombModule(direct_coulomb_erf_damping_sigma=1.0)
+
+        positions = batch.node_features["positions"]
+        positions.requires_grad_(True)
+        charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
+        energy, explicit_forces, _ = coulomb(charges, batch)
+        total_f = _total_forces(energy, explicit_forces, positions)
+
+        # Backprop through total forces to charge model weights
+        total_f.sum().backward()
+        linear = charge_fn[1]  # Linear layer inside Sequential
+        assert linear.weight.grad is not None
+        assert linear.weight.grad.abs().sum() > 0
+
+    def test_total_forces(self):
+        """Total force (explicit + autograd) with q=q(r) matches finite difference.
+
+        Use double precision to avoid numerical instability in finite difference.
+        """
+        atoms = ase.Atoms("H2O", positions=[[0, 0, 0], [0.96, 0, 0], [0.24, 0.93, 0]])
+        batch = _make_batch([atoms])
+        charge_fn = _make_charge_fn(n_atoms=3).double()
+        coulomb = CoulombModule(direct_coulomb_erf_damping_sigma=1.0)
+
+        # Autograd total forces
+        positions = batch.node_features["positions"].double()
+        batch.node_features["positions"] = positions
+        positions.requires_grad_(True)
+        charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
+        energy, explicit_forces, _ = coulomb(charges, batch)
+        forces_auto = _total_forces(energy, explicit_forces, positions)
+
+        def energy_fn(pos):
+            batch.node_features["positions"] = pos
+            q = charge_fn(pos.unsqueeze(0)).squeeze(0)
+            e, _, _ = coulomb(q, batch)
+            return e.sum()
+
+        forces_fd = _fd_forces(energy_fn, positions)
+        torch.testing.assert_close(forces_auto.detach(), forces_fd, atol=1e-5, rtol=1e-5)
+
+
+class TestPeriodic:
+    """PME for periodic systems — energy, forces, stress, gradient flow."""
+
+    def test_shapes_and_finiteness(self):
+        batch = _make_batch(_water_molecules())
+        n_atoms = batch.node_features["positions"].shape[0]
+        charges = torch.randn(n_atoms, 1)
+
+        coulomb = _get_coulomb_module()
+        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
+
+        assert energy.shape == (2,)
+        assert torch.isfinite(energy).all()
+        assert explicit_forces.shape == (n_atoms, 3)
+        assert explicit_stress.shape == (2, 6)
+        assert explicit_forces.abs().sum() > 0
+        assert explicit_stress.abs().sum() > 0
+
+    def test_opposite_charges_attract(self):
+        atoms = ase.Atoms(
+            "NaCl",
+            positions=[[0, 0, 0], [2, 0, 0]],
+            cell=[20, 20, 20],
+            pbc=True,
+        )
+        batch = _make_batch([atoms])
+        charges = torch.tensor([[1.0], [-1.0]])
+
+        coulomb = CoulombModule(pme_accuracy=1e-6)
+        energy, _, _ = coulomb(charges, batch)
+
+        assert energy.item() < 0, "Opposite charges should attract (negative energy)"
+
+    def test_vacuum_gap_convergence(self):
+        """Periodic Ewald in large box converges to non-periodic direct sum."""
+        torch.manual_seed(42)
+        positions = [[0, 0, 0], [0.96, 0, 0], [0.24, 0.93, 0]]
+        charges_val = torch.randn(3, 1)
+
+        # Non-periodic reference
+        atoms_np = ase.Atoms("H2O", positions=positions)
+        batch_np = _make_batch([atoms_np])
+        coulomb = CoulombModule(direct_coulomb_erf_damping_sigma=0.5)
+        e_nonperiodic, _, _ = coulomb(charges_val, batch_np)
+
+        # Periodic with increasing box size
+        energies = []
+        for box_size in [15.0, 25.0, 40.0, 100.0]:
+            atoms_p = ase.Atoms("H2O", positions=positions, cell=[box_size] * 3, pbc=True)
+            batch_p = _make_batch([atoms_p])
+            e, _, _ = CoulombModule(direct_coulomb_erf_damping_sigma=0.5, pme_accuracy=1e-6)(
+                charges_val, batch_p
+            )
+            energies.append(e.item())
+
+        errors = [abs(e - e_nonperiodic.item()) for e in energies]
+        assert errors == sorted(errors, reverse=True), (
+            f"Ewald should monotonically converge to direct sum: errors={errors}"
+        )
+
+    def test_dEdq_nonzero(self):
+        batch = _make_batch(_water_molecules())
+        n_atoms = batch.node_features["positions"].shape[0]
+        charges = torch.randn(n_atoms, 1, requires_grad=True)
+
+        coulomb = _get_coulomb_module()
+        energy, _, _ = coulomb(charges, batch)
+
+        grad = torch.autograd.grad(energy.sum(), charges)[0]
+        assert grad is not None
+        assert grad.abs().sum() > 0
+
+    def test_explicit_stress_nonzero(self):
+        batch = _make_batch(_water_molecules())
+        n_atoms = batch.node_features["positions"].shape[0]
+        torch.manual_seed(42)
+        charges = torch.randn(n_atoms, 1)
+
+        coulomb = _get_coulomb_module()
+        _, _, explicit_stress = coulomb(charges, batch)
+
+        assert explicit_stress.abs().sum() > 0
+
+    def test_spatial_forces(self):
+        """Spatial forces (fixed charges) match finite difference.
+
+        With fixed charges, positions are detached inside PME, so the spatial
+        component lives entirely in explicit_forces (no autograd component).
+
+        Use double precision to avoid numerical instability in finite difference.
+        """
+        atoms = ase.Atoms(
+            "NaCl",
+            positions=[[2, 5, 5], [8, 5, 5]],
+            cell=[10, 10, 10],
+            pbc=True,
+        )
+
+        batch = _make_batch([atoms])
+        batch.node_features["positions"] = batch.node_features["positions"].double()
+        batch.system_features["cell"] = batch.system_features["cell"].double()
+        charges = torch.tensor([[1.0], [-1.0]], dtype=torch.float64)
+        coulomb = CoulombModule(pme_accuracy=1e-6)
+
+        _, explicit_forces, _ = coulomb(charges, batch)
+
+        pos_base = batch.node_features["positions"]
+
+        def force_energy_fn(pos):
+            batch.node_features["positions"] = pos
+            e, _, _ = coulomb(charges, batch)
+            return e.sum()
+
+        forces_fd = _fd_forces(force_energy_fn, pos_base)
+        torch.testing.assert_close(explicit_forces, forces_fd, atol=1e-5, rtol=1e-5)
+
+    def test_spatial_stress(self):
+        """Spatial stress (fixed charges) matches finite difference.
+
+        With fixed charges, positions are detached inside PME, so the spatial
+        component lives entirely in explicit_stress (no autograd component).
+
+        Use double precision to avoid numerical instability in finite difference.
+        """
+        atoms = ase.Atoms(
+            "NaCl",
+            positions=[[2, 5, 5], [8, 5, 5]],
+            cell=[10, 10, 10],
+            pbc=True,
+        )
+
+        batch = _make_batch([atoms])
+        batch.node_features["positions"] = batch.node_features["positions"].double()
+        batch.system_features["cell"] = batch.system_features["cell"].double()
+        charges = torch.tensor([[1.0], [-1.0]], dtype=torch.float64)
+        coulomb = CoulombModule(pme_accuracy=1e-6)
+
+        _, _, explicit_stress = coulomb(charges, batch)
+
+        pos_base = batch.node_features["positions"]
+        cell_base = batch.system_features["cell"]
+
+        def virial_energy_fn(pos, cell):
+            batch.node_features["positions"] = pos
+            batch.system_features["cell"] = cell
+            e, _, _ = coulomb(charges, batch)
+            return e.sum()
+
+        stress_fd = _fd_stress(virial_energy_fn, pos_base, cell_base)
+        torch.testing.assert_close(explicit_stress.squeeze(0), stress_fd, atol=1e-5, rtol=1e-5)
+
+    def test_spatial_forces_not_differentiable_wrt_charges_model(self):
+        """Explicit forces are *not* differentiable w.r.t. charge model."""
+        batch = _make_batch(_water_molecules()[:1])
+        n_atoms = batch.node_features["positions"].shape[0]
+        charge_fn = _make_charge_fn(n_atoms=n_atoms)
+        charge_fn.train()
+        coulomb = _get_coulomb_module()
+        coulomb.train()
+
+        positions = batch.node_features["positions"].clone().requires_grad_(True)
+        batch.node_features["positions"] = positions
+        charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
+        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
+
+        assert explicit_forces.requires_grad is False, (
+            "explicit_forces should not be differentiable"
+        )
+
+    def test_spatial_stress_not_differentiable_wrt_charges_model(self):
+        """Explicit stress is *not* differentiable w.r.t. charge model."""
+        batch = _make_batch(_water_molecules()[:1])
+        n_atoms = batch.node_features["positions"].shape[0]
+        charge_fn = _make_charge_fn(n_atoms=n_atoms)
+        charge_fn.train()
+        coulomb = _get_coulomb_module()
+        coulomb.train()
+
+        positions = batch.node_features["positions"].clone().requires_grad_(True)
+        batch.node_features["positions"] = positions
+        charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
+        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
+
+        assert explicit_stress.requires_grad is False, (
+            "explicit_stress should not be differentiable"
+        )
+
+    def test_total_forces_differentiable_wrt_charges_model(self):
+        """Total forces are differentiable w.r.t. charge model."""
+        batch = _make_batch(_water_molecules()[:1])
+        n_atoms = batch.node_features["positions"].shape[0]
+        charge_fn = _make_charge_fn(n_atoms=n_atoms)
+        charge_fn.train()
+        coulomb = _get_coulomb_module()
+        coulomb.train()
+
+        positions = batch.node_features["positions"].clone().requires_grad_(True)
+        batch.node_features["positions"] = positions
+        charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
+        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
+
+        total_forces = _total_forces(energy, explicit_forces, positions)
+
+        linear = charge_fn[1]
+        total_forces.sum().backward()
+        assert linear.weight.grad is not None, (
+            "total_forces should be differentiable w.r.t. charge model"
+        )
+        assert linear.weight.grad.abs().sum() > 0
+
+    def test_total_stress_differentiable_wrt_charges_model(self):
+        """Total stress is differentiable w.r.t. charge model."""
+        batch = _make_batch(_water_molecules()[:1])
+        n_atoms = batch.node_features["positions"].shape[0]
+        charge_fn = _make_charge_fn(n_atoms=n_atoms)
+        charge_fn.train()
+        coulomb = _get_coulomb_module()
+        coulomb.train()
+
+        pos_base = batch.node_features["positions"].clone()
+        cell_base = batch.system_features["cell"]
+
+        strain = torch.zeros(3, 3, dtype=pos_base.dtype, requires_grad=True)
+        strained_pos, strained_cell = _apply_strain(pos_base, cell_base, strain)
+        batch.node_features["positions"] = strained_pos
+        batch.system_features["cell"] = strained_cell
+
+        charges = charge_fn(strained_pos.unsqueeze(0)).squeeze(0)
+        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
+
+        total_stress = _total_stress(energy, explicit_stress, strain, strained_cell)
+
+        linear = charge_fn[1]
+        total_stress.sum().backward()
+        assert linear.weight.grad is not None, (
+            "total_stress should be differentiable w.r.t. charge model"
+        )
+        assert linear.weight.grad.abs().sum() > 0
+
+    def test_combined_loss_differentiable_wrt_charges_model(self):
+        """Combined loss on energy, total forces, and total virial is differentiable w.r.t. charge model.
+
+        This is mostly just a smoke test to ensure that this works.
+        """
+        batch = _make_batch(_water_molecules()[:1])
+        n_atoms = batch.node_features["positions"].shape[0]
+        charge_fn = _make_charge_fn(n_atoms=n_atoms)
+        charge_fn.train()
+        coulomb = _get_coulomb_module()
+        coulomb.train()
+
+        pos_base = batch.node_features["positions"].clone()
+        cell_base = batch.system_features["cell"]
+
+        # Apply differentiable strain for virial
+        strain = torch.zeros(3, 3, dtype=pos_base.dtype, requires_grad=True)
+        strained_pos, strained_cell = _apply_strain(pos_base, cell_base, strain)
+        positions = strained_pos.requires_grad_(True)
+        batch.node_features["positions"] = positions
+        batch.system_features["cell"] = strained_cell
+
+        charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
+        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
+
+        total_forces, total_stress = _total_forces_and_stress(
+            energy,
+            explicit_forces,
+            explicit_stress,
+            positions,
+            strain,
+            strained_cell,
+            training=True,
+        )
+
+        linear = charge_fn[1]
+        loss = energy.sum() + total_forces.sum() + total_stress.sum()
+        loss.backward()
+
+        assert linear.weight.grad is not None, (
+            "combined loss should be differentiable w.r.t. charge model"
+        )
+        assert linear.weight.grad.abs().sum() > 0
+
+    def test_charge_equilibration_gradient_flows(self):
+        """dE/dq and dE/dr through q(r) are nonzero in eval mode."""
+        atoms = ase.Atoms(
+            "NaCl",
+            positions=[[2, 5, 5], [8, 5, 5]],
+            cell=[10, 10, 10],
+            pbc=True,
+        )
+        batch = _make_batch([atoms])
+        charge_fn = _make_charge_fn(n_atoms=2)
+        coulomb = _get_coulomb_module()
+
+        positions = batch.node_features["positions"]
+        positions.requires_grad_(True)
+        charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
+        energy, _, _ = coulomb(charges, batch)
+
+        # dE/dq should be nonzero
+        dEdq = torch.autograd.grad(energy.sum(), charges, retain_graph=True)[0]
+        assert dEdq.abs().sum() > 0, "dE/dq should be nonzero"
+
+        # dE/dr through q(r) chain rule should be nonzero
+        dEdr = torch.autograd.grad(energy.sum(), positions)[0]
+        assert dEdr.abs().sum() > 0, "dE/dr through q(r) should be nonzero"
+
+    def test_total_forces(self):
+        """Total force with q=q(r) matches finite difference.
+
+        Use double precision to avoid numerical instability in finite difference.
+        """
+        atoms = ase.Atoms(
+            "NaCl",
+            positions=[[2, 5, 5], [8, 5, 5]],
+            cell=[10, 10, 10],
+            pbc=True,
+        )
+        batch = _make_batch([atoms])
+        batch.node_features["positions"] = batch.node_features["positions"].double()
+        batch.system_features["cell"] = batch.system_features["cell"].double()
+        charge_fn = _make_charge_fn(n_atoms=2).double()
+        coulomb = _get_coulomb_module()
+
+        positions = batch.node_features["positions"]
+        positions.requires_grad_(True)
+        charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
+        energy, explicit_forces, _ = coulomb(charges, batch)
+        forces_auto = _total_forces(energy, explicit_forces, positions)
+
+        def energy_fn(pos):
+            batch.node_features["positions"] = pos
+            q = charge_fn(pos.unsqueeze(0)).squeeze(0)
+            e, _, _ = coulomb(q, batch)
+            return e.sum()
+
+        forces_fd = _fd_forces(energy_fn, positions)
+        torch.testing.assert_close(forces_auto.detach(), forces_fd, atol=1e-5, rtol=1e-5)
+
+    def test_total_stress(self):
+        """Total stress with q=q(r) matches finite difference.
+
+        Use double precision to avoid numerical instability in finite difference.
+        Pin PME parameters so FD perturbations don't re-estimate them (discrete
+        jumps in mesh_dimensions would make the energy non-smooth w.r.t. strain).
+        """
+
+        atoms = ase.Atoms(
+            "NaCl",
+            positions=[[8, 9, 10], [12, 11, 10.5]],
+            cell=[20, 20, 20],
+            pbc=True,
+        )
+        batch = _make_batch([atoms])
+        batch.node_features["positions"] = batch.node_features["positions"].double()
+        batch.system_features["cell"] = batch.system_features["cell"].double()
+        charge_fn = _make_charge_fn(n_atoms=2).double()
+        coulomb = _get_coulomb_module()
+
+        pos_base = batch.node_features["positions"]
+        cell_base = batch.system_features["cell"]
+
+        # Pin all PME parameters so FD perturbations don't re-estimate them.
+        params = estimate_pme_parameters(
+            pos_base,
+            cell_base,
+            batch_idx=torch.zeros(pos_base.shape[0], dtype=torch.int32),
+            accuracy=coulomb.pme_accuracy,
+        )
+        fixed_pme = {
+            "pme_alpha": params.alpha.item(),
+            "pme_cutoff": params.real_space_cutoff.max().item(),
+            "pme_mesh_dimensions": tuple(params.mesh_dimensions),
+        }
+
+        # Apply a differentiable strain so autograd can compute dE/dε
+        strain = torch.zeros(3, 3, dtype=torch.float64, requires_grad=True)
+        strained_pos, strained_cell = _apply_strain(pos_base, cell_base, strain)
+        batch.node_features["positions"] = strained_pos
+        batch.system_features["cell"] = strained_cell
+
+        charges = charge_fn(strained_pos.unsqueeze(0)).squeeze(0)
+        energy, _, explicit_stress = coulomb(charges, batch, kwargs=fixed_pme)
+        stress_auto = _total_stress(energy, explicit_stress, strain, strained_cell)
+
+        def virial_energy_fn(pos, cell):
+            batch.node_features["positions"] = pos
+            batch.system_features["cell"] = cell
+            q = charge_fn(pos.unsqueeze(0)).squeeze(0)
+            e, _, _ = coulomb(q, batch, kwargs=fixed_pme)
+            return e.sum()
+
+        stress_fd = _fd_stress(virial_energy_fn, pos_base, cell_base)
+        torch.testing.assert_close(stress_auto.detach(), stress_fd, atol=1e-5, rtol=1e-5)
+
+    def test_positions_detached_both_modes(self):
+        """Positions are detached inside PME in both train/eval modes.
+
+        Spatial forces come only from explicit_forces, not through autograd on energy.
+        """
+        batch = _make_batch(_water_molecules()[:1])
+        n_atoms = batch.node_features["positions"].shape[0]
+        for mode in ["train", "eval"]:
+            coulomb = _get_coulomb_module()
+            getattr(coulomb, mode)()
+
+            positions = batch.node_features["positions"].clone().requires_grad_(True)
+            batch.node_features["positions"] = positions
+            # Charges require grad so the energy stays in the compute graph
+            charges = torch.randn(n_atoms, 1, requires_grad=True)
+            energy, explicit_forces, _ = coulomb(charges, batch)
+
+            # dE/dr through the energy should be None (positions detached inside PME)
+            grad = torch.autograd.grad(
+                energy.sum(), positions, allow_unused=True, retain_graph=True
+            )[0]
+            assert grad is None or (grad.abs() < 1e-10).all(), (
+                f"In {mode} mode, positions should be detached inside PME"
+            )
+
+            # But explicit_forces should be nonzero
+            assert explicit_forces.abs().sum() > 0, (
+                f"In {mode} mode, explicit_forces should carry the spatial component"
+            )
+
+    def test_cell_detached_both_modes(self):
+        """Cell is detached inside PME in both train/eval modes.
+
+        Stress contributions come only from explicit_stress, not through autograd
+        on energy w.r.t. strain.
+        """
+        batch = _make_batch(_water_molecules()[:1])
+        n_atoms = batch.node_features["positions"].shape[0]
+        for mode in ["train", "eval"]:
+            coulomb = _get_coulomb_module()
+            getattr(coulomb, mode)()
+
+            pos = batch.node_features["positions"].clone()
+            cell = batch.system_features["cell"].clone()
+            strain = torch.zeros(3, 3, requires_grad=True)
+            strained_pos, strained_cell = _apply_strain(pos, cell, strain)
+            batch.node_features["positions"] = strained_pos
+            batch.system_features["cell"] = strained_cell
+
+            charges = torch.randn(n_atoms, 1, requires_grad=True)
+            energy, _, explicit_stress = coulomb(charges, batch)
+
+            # dE/dε through the energy should be None (cell detached inside PME)
+            grad = torch.autograd.grad(energy.sum(), strain, allow_unused=True, retain_graph=True)[
+                0
+            ]
+            assert grad is None or (grad.abs() < 1e-10).all(), (
+                f"In {mode} mode, cell should be detached inside PME"
+            )
+
+            # But explicit_stress should be nonzero
+            assert explicit_stress.abs().sum() > 0, (
+                f"In {mode} mode, explicit_stress should carry the stress component"
+            )
+
+
+class TestBatching:
+    """Batched computation matches individual system computation."""
+
+    def test_nonperiodic_batched_vs_individual(self):
+        molecules = _nonperiodic_molecules()
+        coulomb = _get_coulomb_module()
+
+        individual_energies = []
+        all_charges = []
+        for mol in molecules:
+            n = len(mol)
+            q = torch.randn(n, 1)
+            all_charges.append(q)
+            e, _, _ = coulomb(q, _make_batch([mol]))
+            individual_energies.append(e.item())
+
+        batch = _make_batch(molecules)
+        charges = torch.cat(all_charges, dim=0)
+        batched_energies, _, _ = coulomb(charges, batch)
+
+        for i, (batched, individual) in enumerate(
+            zip(batched_energies.tolist(), individual_energies, strict=True)
+        ):
+            assert batched == pytest.approx(individual, rel=1e-5), (
+                f"System {i}: batched={batched}, individual={individual}"
+            )
+
+    def test_periodic_batched_vs_individual(self):
+        """Energy, explicit_forces, and stress match between batched and individual."""
+        waters = _water_molecules()
+        coulomb = _get_coulomb_module()
+
+        individual_energies = []
+        individual_forces = []
+        individual_stresses = []
+        all_charges = []
+        for mol in waters:
+            n = len(mol)
+            q = torch.randn(n, 1)
+            all_charges.append(q)
+            e, f, v = coulomb(q, _make_batch([mol]))
+            individual_energies.append(e.item())
+            individual_forces.append(f)
+            individual_stresses.append(v)
+
+        batch = _make_batch(waters)
+        charges = torch.cat(all_charges, dim=0)
+        batched_energies, batched_forces, batched_stress = coulomb(charges, batch)
+
+        # Energy
+        for i, (batched, individual) in enumerate(
+            zip(batched_energies.tolist(), individual_energies, strict=True)
+        ):
+            assert batched == pytest.approx(individual, rel=1e-5), (
+                f"Energy system {i}: batched={batched}, individual={individual}"
+            )
+
+        # Forces (slice by n_node)
+        n_node = batch.n_node
+        offset = 0
+        for i, n in enumerate(n_node):
+            torch.testing.assert_close(
+                batched_forces[offset : offset + n],
+                individual_forces[i],
+                atol=1e-3,
+                rtol=1e-3,
+            )
+            offset += n
+
+        # Stress
+        for i in range(len(waters)):
+            torch.testing.assert_close(
+                batched_stress[i : i + 1],
+                individual_stresses[i],
+                atol=1e-3,
+                rtol=1e-3,
+            )
+
+    def test_mixed_periodic_nonperiodic(self):
+        """Mixed batch: each system matches its individual computation."""
+        periodic = ase.Atoms(
+            "H2O",
+            positions=[[0, 0, 0], [0.96, 0, 0], [0.24, 0.93, 0]],
+            cell=[10, 10, 10],
+            pbc=True,
+        )
+        nonperiodic = ase.Atoms("H2", positions=[[0, 0, 0], [0.74, 0, 0]])
+
+        coulomb = _get_coulomb_module()
+
+        q_periodic = torch.randn(3, 1)
+        q_nonperiodic = torch.randn(2, 1)
+
+        e_periodic, f_periodic, _ = coulomb(q_periodic, _make_batch([periodic]))
+        e_nonperiodic, f_nonperiodic, _ = coulomb(q_nonperiodic, _make_batch([nonperiodic]))
+
+        # Mixed batch
+        mixed_batch = _make_batch([periodic, nonperiodic])
+        mixed_charges = torch.cat([q_periodic, q_nonperiodic], dim=0)
+        mixed_energy, mixed_forces, _ = coulomb(mixed_charges, mixed_batch)
+
+        assert mixed_energy.shape == (2,)
+        torch.testing.assert_close(mixed_energy[0], e_periodic[0], atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(mixed_energy[1], e_nonperiodic[0], atol=1e-5, rtol=1e-5)
+
+        # Non-periodic explicit forces should be zero, periodic should be nonzero
+        assert mixed_forces[:3].abs().sum() > 0, "Periodic explicit forces should be nonzero"
+        assert (mixed_forces[3:].abs() < 1e-10).all(), "Non-periodic explicit forces should be zero"
+
+
+class TestRotationalGradients:
+    """Rotational gradients from CoulombModule energy."""
+
+    @pytest.mark.parametrize(
+        "atoms_fn",
+        [lambda: _water_molecules()[:1], lambda: _nonperiodic_molecules()[:1]],
+        ids=["periodic", "nonperiodic"],
+    )
+    def test_rotational_grad_zero_with_fixed_charges(self, atoms_fn):
+        """dE/d(generator) is zero when charges are independent of geometry.
+
+        Sanity check to ensure that we're not missing a contribution to equigrad gradients,
+        since nvalchemiops detaches positions and cell from the graph.
+
+        Coulomb energy is rotationally invariant, so rotating positions (and cell)
+        via the generator should not change energy — gradient must vanish.
+        """
+        batch = _make_batch(atoms_fn())
+        n_atoms = batch.node_features["positions"].shape[0]
+        coulomb = _get_coulomb_module()
+
+        generator = torch.zeros(1, 3, 3, requires_grad=True)
+        rotation = rotation_from_generator(generator)
+
+        pos = batch.node_features["positions"].clone()
+        batch.node_features["positions"] = pos @ rotation.squeeze(0)
+
+        cell = batch.system_features["cell"]
+        if cell.abs().sum() > 0:
+            batch.system_features["cell"] = cell @ rotation
+
+        charges = torch.randn(n_atoms, 1, requires_grad=True)
+        # For this test, we disable hybrid forces, so that nvalchemiops does not detach positions and cell from the graph.
+        # This allows us to check that the rotational gradient is zero when charges are fixed.
+        # We do this because our normal computation graph with hybrid_forces=True would detach the positions and cell
+        # from the graph _and also_ compute_differentiable_edge_vectors does not set the rotated positions/cell in the AtomGraphs object,
+        # hence their contributions to equigrad regularization would be lost.
+        #
+        # This check tests that we are not missing anything (rotational gradients are 0)
+        energy, _, _ = coulomb(charges, batch, kwargs={"pme_hybrid_forces": False})
+
+        grad = torch.autograd.grad(energy.sum(), generator, allow_unused=True, retain_graph=True)[0]
+        assert (grad.abs() < 1e-7).all(), (
+            f"Rotational gradient should be zero with fixed charges, got {grad}"
+        )
+
+    @pytest.mark.parametrize(
+        "atoms_fn",
+        [lambda: _water_molecules()[:1], lambda: _nonperiodic_molecules()[:1]],
+        ids=["periodic", "nonperiodic"],
+    )
+    def test_rotational_grad_nonzero_with_position_dependent_charges(self, atoms_fn):
+        """dE/d(generator) is nonzero when charges depend on rotated positions.
+
+        Gradient flows through energy -> charges -> generator, breaking rotational invariance.
+        """
+        batch = _make_batch(atoms_fn())
+        n_atoms = batch.node_features["positions"].shape[0]
+        coulomb = _get_coulomb_module()
+        charge_fn = _make_charge_fn(n_atoms)
+
+        generator = torch.zeros(1, 3, 3, requires_grad=True)
+        rotation = rotation_from_generator(generator)
+
+        pos = batch.node_features["positions"].clone()
+        rotated_pos = pos @ rotation.squeeze(0)
+        batch.node_features["positions"] = rotated_pos
+
+        cell = batch.system_features["cell"]
+        if cell.abs().sum() > 0:
+            batch.system_features["cell"] = cell @ rotation
+
+        charges = charge_fn(rotated_pos.unsqueeze(0)).squeeze(0)
+        energy, _, _ = coulomb(charges, batch)
+
+        grad = torch.autograd.grad(energy.sum(), generator)[0]
+        assert grad.abs().sum() > 0.5, (
+            "Rotational gradient should be nonzero with position-dependent charges"
+        )
+
+
+class TestFullyConnectedSendersReceivers:
+    """Tests for _fully_connected_senders_receivers helper."""
+
+    def test_single_system(self):
+        n_node = torch.tensor([3])
+        senders, receivers = _fully_connected_senders_receivers(n_node, torch.device("cpu"))
+
+        # 3 atoms -> 3*2 = 6 directed pairs (no self-loops)
+        assert senders.shape[0] == 6
+        assert receivers.shape[0] == 6
+
+        pairs = set(zip(senders.tolist(), receivers.tolist(), strict=True))
+        expected = {(i, j) for i in range(3) for j in range(3) if i != j}
+        assert pairs == expected
+
+    def test_no_self_loops(self):
+        n_node = torch.tensor([4])
+        senders, receivers = _fully_connected_senders_receivers(n_node, torch.device("cpu"))
+        assert (senders != receivers).all()
+
+    def test_batched_systems(self):
+        n_node = torch.tensor([2, 3])
+        senders, receivers = _fully_connected_senders_receivers(n_node, torch.device("cpu"))
+
+        # System 0: atoms [0,1] -> 2 pairs; System 1: atoms [2,3,4] -> 6 pairs
+        assert senders.shape[0] == 2 + 6
+
+        pairs = set(zip(senders.tolist(), receivers.tolist(), strict=True))
+        expected_sys0 = {(0, 1), (1, 0)}
+        expected_sys1 = {(i, j) for i in range(2, 5) for j in range(2, 5) if i != j}
+        assert pairs == expected_sys0 | expected_sys1
+
+    def test_no_cross_system_pairs(self):
+        n_node = torch.tensor([2, 2])
+        senders, receivers = _fully_connected_senders_receivers(n_node, torch.device("cpu"))
+
+        # Atoms 0,1 in system 0; atoms 2,3 in system 1 — no cross-system pairs
+        for s, r in zip(senders.tolist(), receivers.tolist(), strict=True):
+            assert (s < 2 and r < 2) or (s >= 2 and r >= 2)
+
+    def test_single_atom_system(self):
+        n_node = torch.tensor([1])
+        senders, receivers = _fully_connected_senders_receivers(n_node, torch.device("cpu"))
+        assert senders.shape[0] == 0
+        assert receivers.shape[0] == 0
+
+
+class TestEdgeCases:
+    def test_single_atom(self):
+        # Non-periodic: zero energy (no pairs)
+        atoms_np = ase.Atoms("H", positions=[[0, 0, 0]])
+        batch_np = _make_batch([atoms_np])
+        charges = torch.tensor([[1.0]])
+        coulomb = _get_coulomb_module()
+        energy, _, _ = coulomb(charges, batch_np)
+        assert energy.item() == pytest.approx(0.0, abs=1e-6)
+
+        # Periodic: finite energy
+        atoms_p = ase.Atoms("H", positions=[[0, 0, 0]], cell=[10, 10, 10], pbc=True)
+        batch_p = _make_batch([atoms_p])
+        coulomb_p = _get_coulomb_module()
+        energy_p, _, _ = coulomb_p(charges, batch_p)
+        assert torch.isfinite(energy_p).all()
+
+    def test_mixed_system_sizes(self):
+        atoms_list = [
+            ase.Atoms("H", positions=[[0, 0, 0]]),
+            ase.Atoms("H2", positions=[[0, 0, 0], [1, 0, 0]]),
+            ase.Atoms("H2O", positions=[[0, 0, 0], [0.96, 0, 0], [0.24, 0.93, 0]]),
+        ]
+        batch = _make_batch(atoms_list)
+        n_atoms = batch.node_features["positions"].shape[0]
+        charges = torch.randn(n_atoms, 1)
+
+        coulomb = _get_coulomb_module()
+        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
+
+        assert energy.shape == (3,)
+        assert explicit_forces.shape == (n_atoms, 3)
+        assert explicit_stress.shape == (3, 6)
+        assert torch.isfinite(energy).all()
+
+    def test_partial_pbc_raises(self):
+        # Build a valid periodic batch, then override pbc to partial
+        atoms = ase.Atoms(
+            "H2",
+            positions=[[0, 0, 0], [1, 0, 0]],
+            cell=[10, 10, 10],
+            pbc=True,
+        )
+        batch = _make_batch([atoms])
+        batch.system_features["pbc"] = torch.tensor([[True, False, False]])
+        charges = torch.tensor([[1.0], [-1.0]])
+
+        coulomb = _get_coulomb_module()
+        with pytest.raises(NotImplementedError, match="1D and 2D PBC"):
+            coulomb(charges, batch)


### PR DESCRIPTION
Key changes:
* `predict()` output cleanup + `OrbCalculator` and `OrbTorchSimModel`
* `forward()` output cleanup + preparation for Nvalchemi OrbWrapper
* Fixed `DirectRegressor.predict()` missing the compiled path. (Changed call from `self.forward(batch)` to `self(batch)`.
* Ported missing `test_coulomb_module.py`
* Other misc changes