### PR TITLE
ALCHEMI-Toolkit wrapper for Orb

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -22,6 +22,7 @@ Trained on OMol25 and OPoly26 (ωB97M-V/def2-TZVPD); supports both periodic and 
 
 ```python
 from orb_models.forcefield.pretrained import orbmol_v2
+
 model, atoms_adapter = orbmol_v2(device="cuda")
 # atoms.info["charge"] and atoms.info["spin"] (multiplicity, = 2S+1) must be set.
 ```

--- a/README.md
+++ b/README.md
@@ -197,12 +197,12 @@ import torch
 from ase.build import bulk
 
 from nvalchemi.data import AtomicData, Batch
-from nvalchemi.dynamics import FIRE, ConvergenceHook, DynamicsStage
+from nvalchemi.dynamics import FIRE, ConvergenceHook, DynamicsStage, FusedStage
 from nvalchemi.hooks import NeighborListHook
 
 from orb_models.forcefield.inference.orb_nvalchemi import OrbWrapper
 
-device = "cuda"  # or device="cuda"
+device = "cpu"  # or device="cuda"
 orb = OrbWrapper.from_pretrained("orb-v3-conservative-inf-omat", device=device)
 
 nl_hook = NeighborListHook(
@@ -219,11 +219,16 @@ optimizer = FIRE(
     model=orb,
     dt=1.0,
     n_steps=100,
-    hooks=[nl_hook],
     convergence_hook=ConvergenceHook.from_fmax(0.01),
 )
-with optimizer:
-    relaxed = optimizer.run(batch)
+# Fuse and torch.compile the whole dynamics step
+fused = FusedStage(
+    sub_stages=[(0, optimizer)],
+    hooks=[nl_hook],
+    compile_step=True,
+)
+with fused:
+    relaxed = fused.run(batch)
 print("Optimized energy:", orb(relaxed)["energy"])
 ```
 
@@ -234,14 +239,13 @@ import torch
 from ase.build import bulk
 
 from nvalchemi.data import AtomicData, Batch
-from nvalchemi.dynamics import FIRE, ConvergenceHook, DynamicsStage
-from nvalchemi.hooks import NeighborListHook
+from nvalchemi.dynamics import FIRE, ConvergenceHook, FusedStage
 from nvalchemi.models.dftd3 import DFTD3ModelWrapper
 from nvalchemi.models.pipeline import PipelineGroup, PipelineModelWrapper
 
 from orb_models.forcefield.inference.orb_nvalchemi import OrbWrapper
 
-device = "cuda"  # or device="cuda"
+device = "cpu"  # or device="cuda"
 orb = OrbWrapper.from_pretrained("orb-v3-conservative-inf-omat", device=device)
 
 # DFT-D3 dispersion correction (PBE-BJ parameters)
@@ -251,11 +255,8 @@ d3 = DFTD3ModelWrapper(a1=0.4289, a2=4.4407, s8=0.7875).to(device)
 pipe = PipelineModelWrapper(groups=[
     PipelineGroup(steps=[orb, d3], use_autograd=True),
 ])
-
-nl_hook = NeighborListHook(
-    config=pipe.model_config.neighbor_config,
-    stage=DynamicsStage.BEFORE_COMPUTE,
-)
+pipe.eval()
+nl_hooks = pipe.make_neighbor_hooks()
 
 atoms = bulk("Cu", "fcc", a=3.58, cubic=True)
 atoms.rattle(0.5)
@@ -266,11 +267,16 @@ optimizer = FIRE(
     model=pipe,
     dt=1.0,
     n_steps=100,
-    hooks=[nl_hook],
     convergence_hook=ConvergenceHook.from_fmax(0.01),
 )
-with optimizer:
-    relaxed = optimizer.run(batch)
+# Fuse and torch.compile the whole dynamics step
+fused = FusedStage(
+    sub_stages=[(0, optimizer)],
+    hooks=nl_hooks,
+    compile_step=True,
+)
+with fused:
+    relaxed = fused.run(batch)
 print("Optimized energy:", pipe(relaxed)["energy"])
 ```
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,95 @@ relaxed_state = ts.optimize(
     steps_between_swaps=10,
 )
 results = ts_model(relaxed_state)
-print("Rattled energies:", results["energy"])
+print("Optimized energies:", results["energy"])
+```
+
+#### Usage with NVALCHEMI Toolkit
+
+For integration with [NVALCHEMI Toolkit](https://github.com/NVIDIA/nvalchemi-toolkit), we provide an `OrbWrapper`. This allows using Orb models with nvalchemi's dynamics engines and pipeline composition. It's an optional dependency that can be installed with `pip install nvalchemi-toolkit`.
+
+Standalone geometry optimization with FIRE:
+
+```python
+import torch
+from ase.build import bulk
+
+from nvalchemi.data import AtomicData, Batch
+from nvalchemi.dynamics import FIRE, ConvergenceHook, DynamicsStage
+from nvalchemi.hooks import NeighborListHook
+
+from orb_models.forcefield.inference.orb_nvalchemi import OrbWrapper
+
+device = "cuda"  # or device="cuda"
+orb = OrbWrapper.from_pretrained("orb-v3-conservative-inf-omat", device=device)
+
+nl_hook = NeighborListHook(
+    config=orb.model_config.neighbor_config,
+    stage=DynamicsStage.BEFORE_COMPUTE,
+)
+
+atoms = bulk("Cu", "fcc", a=3.58, cubic=True)
+atoms.rattle(0.5)
+batch = Batch.from_data_list([AtomicData.from_atoms(atoms, device=device)])
+batch.forces = torch.zeros(batch.num_nodes, 3, dtype=batch.positions.dtype, device=device)
+
+optimizer = FIRE(
+    model=orb,
+    dt=1.0,
+    n_steps=100,
+    hooks=[nl_hook],
+    convergence_hook=ConvergenceHook.from_fmax(0.01),
+)
+with optimizer:
+    relaxed = optimizer.run(batch)
+print("Optimized energy:", orb(relaxed)["energy"])
+```
+
+Pipeline composition with DFT-D3 dispersion correction (only for conservative models):
+
+```python
+import torch
+from ase.build import bulk
+
+from nvalchemi.data import AtomicData, Batch
+from nvalchemi.dynamics import FIRE, ConvergenceHook, DynamicsStage
+from nvalchemi.hooks import NeighborListHook
+from nvalchemi.models.dftd3 import DFTD3ModelWrapper
+from nvalchemi.models.pipeline import PipelineGroup, PipelineModelWrapper
+
+from orb_models.forcefield.inference.orb_nvalchemi import OrbWrapper
+
+device = "cuda"  # or device="cuda"
+orb = OrbWrapper.from_pretrained("orb-v3-conservative-inf-omat", device=device)
+
+# DFT-D3 dispersion correction (PBE-BJ parameters)
+d3 = DFTD3ModelWrapper(a1=0.4289, a2=4.4407, s8=0.7875).to(device)
+
+# Combine in a pipeline with shared autograd
+pipe = PipelineModelWrapper(groups=[
+    PipelineGroup(steps=[orb, d3], use_autograd=True),
+])
+
+nl_hook = NeighborListHook(
+    config=pipe.model_config.neighbor_config,
+    stage=DynamicsStage.BEFORE_COMPUTE,
+)
+
+atoms = bulk("Cu", "fcc", a=3.58, cubic=True)
+atoms.rattle(0.5)
+batch = Batch.from_data_list([AtomicData.from_atoms(atoms, device=device)])
+batch.forces = torch.zeros(batch.num_nodes, 3, dtype=batch.positions.dtype, device=device)
+
+optimizer = FIRE(
+    model=pipe,
+    dt=1.0,
+    n_steps=100,
+    hooks=[nl_hook],
+    convergence_hook=ConvergenceHook.from_fmax(0.01),
+)
+with optimizer:
+    relaxed = optimizer.run(batch)
+print("Optimized energy:", pipe(relaxed)["energy"])
 ```
 
 #### How to specify total charge and spin multiplicity for OrbMol

--- a/orb_models/common/atoms/batch/graph_batch.py
+++ b/orb_models/common/atoms/batch/graph_batch.py
@@ -13,6 +13,16 @@ from orb_models.common.torch_utils import torch_lexsort
 _T = TypeVar("_T", bound="AtomGraphs")
 
 
+class DifferentiableGeometry(NamedTuple):
+    """The differentiable geometry produced for conservative forces/stress."""
+
+    edge_vectors: torch.Tensor
+    stress_displacement: torch.Tensor | None
+    rotation_generator: torch.Tensor | None
+    strained_positions: torch.Tensor
+    strained_cell: torch.Tensor
+
+
 class AtomGraphs(AbstractAtomBatch):
     """A batch of atomic systems represented as graphs with edge vectors and indices.
 
@@ -246,8 +256,8 @@ class AtomGraphs(AbstractAtomBatch):
         self,
         use_stress_displacement: bool = True,
         use_rotation: bool = True,
-    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
-        """Compute pbc-aware edge vectors such that gradients flow back to positions.
+    ) -> DifferentiableGeometry:
+        """Compute pbc-aware differentiable geometry for conservative forces/stress.
 
         Args:
             use_stress_displacement (bool): If True, a zero 'displacement' tensor is created
@@ -271,6 +281,10 @@ class AtomGraphs(AbstractAtomBatch):
                 positions, cell, per_node_graph_indices
             )
 
+        # Captured pre-rotation for equivariant consumers (e.g. Coulomb): they are equivariant by construction,
+        # so they stay out of the rotational-gradient path (equigrad regularises only the learned GNN).
+        strained_positions, strained_cell = positions, cell
+
         equigrad_generator = None
         if use_rotation:
             per_node_graph_indices = self._get_per_node_graph_indices()
@@ -284,14 +298,19 @@ class AtomGraphs(AbstractAtomBatch):
             ).squeeze(1)
             cell = torch.bmm(cell, rotation)
 
-        # This is a compilable equivalent of cells.repeat_interleave(self.n_edge, dim=0)
         per_edge_graph_indices = self._get_per_edge_graph_indices()
         cells_repeat = cell[per_edge_graph_indices]  # (nedges, 3, 3)
 
         shifts = torch.bmm(unit_shifts, cells_repeat).squeeze(1)  # (nedges, 3)
         vectors = positions[self.receivers] - positions[self.senders] + shifts
 
-        return vectors, stress_displacement, equigrad_generator
+        return DifferentiableGeometry(
+            stress_displacement=stress_displacement,
+            rotation_generator=equigrad_generator,
+            edge_vectors=vectors,
+            strained_positions=strained_positions,
+            strained_cell=strained_cell,
+        )
 
     def check_edges_allclose(self, other: _T, msg: str = "", tol: float = 1e-6):
         """Assert that the edges of two atomgraphs are equal."""

--- a/orb_models/common/atoms/graph_featurization.py
+++ b/orb_models/common/atoms/graph_featurization.py
@@ -722,31 +722,28 @@ def _compute_neighbor_list_with_fallback(
     cutoff: float,
     batch_idx: torch.Tensor | None = None,
     batch_ptr: torch.Tensor | None = None,
-    initial_safety_factor: float = 1.0,
-    fallback_safety_factor: float = 5.0,
-    atomic_density: float = 0.35,
+    initial_atomic_density: float = 0.35,
+    fallback_atomic_density: float = 0.35 * 5,
     fill_value: int | None = None,
     wrap_positions: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Compute neighbor list with automatic fallback if initial estimate is too low.
 
-    Estimates max neighbors based on atomic density and a safety factor, using less conservative
-    defaults than alchemiops. With default settings, a 6.0 Å radius allows up to 320 neighbors
-    (~2.6x the estimated 120), which suffices for most cases. If the system is very dense,
-    underestimating max neighbors causes silent truncation of random neighbors, so we fallback
-    to a higher safety factor.
+    Estimates max neighbors based on atomic density, using less conservative defaults than alchemiops.
+    With default settings, a 6.0 Å radius allows up to 320 neighbors (~2.6x the estimated 120), which
+    suffices for most cases. If the system is very dense, underestimating max neighbors causes silent
+    truncation of random neighbors, so we fallback to a higher atomic density.
 
-    See: https://nvidia.github.io/warp/modules/sim.html#neighbor-finding
+    See: https://nvidia.github.io/nvalchemi-toolkit-ops/modules/warp/neighbors.html#nvalchemiops.neighbors.neighbor_utils.estimate_max_neighbors
     """
+
     # nvalchemiops produces incorrect results when pbc has shape (3,) for batched inputs
     # so we expand it to (n_systems, 3). We can remove this once it's fixed.
     n_systems = cell.shape[0] if cell.dim() == 3 else 1
     pbc = pbc.view(-1, 3).expand(n_systems, 3).contiguous()
 
-    for safety_factor in [initial_safety_factor, fallback_safety_factor]:
-        max_num_neighbors_alchemi = estimate_max_neighbors(
-            cutoff, atomic_density=atomic_density, safety_factor=safety_factor
-        )
+    for atomic_density in [initial_atomic_density, fallback_atomic_density]:
+        max_num_neighbors_alchemi = estimate_max_neighbors(cutoff, atomic_density=atomic_density)
         neighbor_matrix, num_neighbors, neighbor_shift_matrix = nva_neighbor_list(
             positions=positions,
             cell=cell,
@@ -762,9 +759,8 @@ def _compute_neighbor_list_with_fallback(
             return neighbor_matrix, num_neighbors, neighbor_shift_matrix
 
     raise RuntimeError(
-        f"max_num_neighbors_alchemi ({max_num_neighbors_alchemi}) is insufficient "
-        f"even with safety_factor={fallback_safety_factor}. "
-        f"Observed max neighbors: {num_neighbors.max().item()}"
+        f"max_num_neighbors_alchemi ({max_num_neighbors_alchemi}) is insufficient even with higher "
+        f"atomic density={fallback_atomic_density}. Observed max neighbors: {num_neighbors.max().item()}"
     )
 
 

--- a/orb_models/common/models/gns.py
+++ b/orb_models/common/models/gns.py
@@ -396,6 +396,7 @@ class MoleculeGNS(base.ModelMixin):
                 f"The following kwargs are not arguments to MoleculeGNS: {kwargs.keys()}"
             )
 
+        self.latent_dim = latent_dim
         self.node_feature_names = node_feature_names or []
         self.edge_feature_names = edge_feature_names or []
         self.num_message_passing_steps = num_message_passing_steps

--- a/orb_models/forcefield/inference/d3_model.py
+++ b/orb_models/forcefield/inference/d3_model.py
@@ -67,13 +67,11 @@ class AlchemiDFTD3(torch.nn.Module):
         # Performance tuning: we estimate the number of maximum neighbors given a radius based on
         # assumed atomic density and a safety factor. We override the default parameters from alchemi,
         # which are *extremely* conservative.
-        # With the safety_factor, a radius of 22.0 Å will allow for up to 8928 neighbors per atom,
-        # which is ~9x lower than the default 78064 neighbors.
+        # With a radius of 22.0 Å allows up to 8928 neighbors per atom, ~9x lower than the default 78064 neighbors.
         # See https://nvidia.github.io/nvalchemi-toolkit-ops/userguide/components/neighborlist.html#performance-tuning
-        # NOTE: If the system is very dense, underestimating max_num_neighbors_alchemi will cause
-        # alchemiops to *silently* truncate a number of *random* neighbors.
-        # To avoid silent errors we use a fallback safety factor, and if that fails raise an error in
-        # _compute_neighbor_list_with_fallback.
+        # NOTE: If the system is very dense, underestimating max_num_neighbors_alchemi will cause alchemiops
+        # to *silently* truncate a number of *random* neighbors.
+        # _compute_neighbor_list_with_fallback detects this, retries with fallback_safety_factor, and raises if that is still insufficient.
         self.atomic_density = 0.2 / ANGSTROM_TO_BOHR**3  # Å^3 -> Bohr^3
         self.safety_factor = 1.0
         self.fallback_safety_factor = 5.0
@@ -149,9 +147,8 @@ class AlchemiDFTD3(torch.nn.Module):
                     pbc=pbc,
                     cutoff=self.cutoff,
                     batch_idx=node_batch_index,
-                    atomic_density=self.atomic_density,
-                    initial_safety_factor=self.safety_factor,
-                    fallback_safety_factor=self.fallback_safety_factor,
+                    initial_atomic_density=self.atomic_density * self.safety_factor,
+                    fallback_atomic_density=self.atomic_density * self.fallback_safety_factor,
                     wrap_positions=True,
                 )
             )

--- a/orb_models/forcefield/inference/orb_nvalchemi.py
+++ b/orb_models/forcefield/inference/orb_nvalchemi.py
@@ -1,0 +1,397 @@
+"""Orb model wrapper for the nvalchemi-toolkit framework.
+
+Wraps Orb forcefield models as a :class:`~nvalchemi.models.base.BaseModelMixin`-compatible
+wrapper for use in any :class:`~nvalchemi.dynamics.base.BaseDynamics` engine, standalone
+inference, or pipeline composition.
+
+Usage
+-----
+Load a pretrained Orb model::
+
+    from core.forcefield.inference.orb_nvalchemi import OrbWrapper
+    import torch
+
+    model = OrbWrapper.from_pretrained("orb-v3-conservative-omol", device=torch.device("cuda"))
+
+Or wrap an already-loaded model::
+
+    from core import interface
+    orb_model, config, adapter = interface.orb_v3_conservative_omol(device="cuda")
+    model = OrbWrapper(orb_model, adapter)
+
+Pipeline composition::
+
+    # Orb + DFT-D3 with shared autograd (conservative models)
+    pipe = PipelineModelWrapper(groups=[
+        PipelineGroup(steps=[orb_wrapper, dftd3_wrapper], use_autograd=True),
+    ])
+
+Notes
+-----
+* Conservative models declare ``autograd_outputs`` so they can participate in
+  nvalchemi pipeline autograd groups. Direct models do not.
+* Models with a CoulombModule expose analytical spatial forces/stress via
+  ``analytic_derivative_keys``. In pipeline autograd mode these are passed
+  through to the pipeline, which sums them with autograd derivatives.
+* Stress is converted from Orb's Voigt-6 notation to the full 3x3 tensor.
+"""
+
+from collections import OrderedDict
+from typing import Any, cast
+
+import torch
+from torch import nn
+
+try:
+    from nvalchemi._typing import ModelOutputs
+    from nvalchemi.data import AtomicData, Batch
+    from nvalchemi.models.base import (
+        BaseModelMixin,
+        ModelConfig,
+        NeighborConfig,
+        NeighborListFormat,
+    )
+except ImportError as e:
+    raise ImportError(
+        "nvalchemi is required for the OrbWrapper interface. "
+        "Install it with: pip install nvalchemi-toolkit"
+    ) from e
+
+from orb_models.common.atoms.batch.graph_batch import AtomGraphs
+from orb_models.common.models.gns import MoleculeGNS
+from orb_models.forcefield import pretrained
+from orb_models.forcefield.forcefield_adapter import ForcefieldAtomsAdapter
+from orb_models.forcefield.models.conservative_regressor import ConservativeForcefieldRegressor
+from orb_models.forcefield.models.direct_regressor import DirectForcefieldRegressor
+
+__all__ = ["OrbWrapper"]
+
+_OrbModel = DirectForcefieldRegressor | ConservativeForcefieldRegressor
+
+
+def _voigt_6_to_full_3x3(voigt: torch.Tensor) -> torch.Tensor:
+    """Convert Voigt notation ``[*, 6]`` to full symmetric tensor ``[*, 3, 3]``."""
+    xx, yy, zz, yz, xz, xy = voigt.unbind(-1)
+    row0 = torch.stack([xx, xy, xz], dim=-1)
+    row1 = torch.stack([xy, yy, yz], dim=-1)
+    row2 = torch.stack([xz, yz, zz], dim=-1)
+    return torch.stack([row0, row1, row2], dim=-2)
+
+
+class OrbWrapper(nn.Module, BaseModelMixin):
+    """Wrapper for Orb models implementing the nvalchemi :class:`BaseModelMixin` interface.
+
+    Accepts ``DirectForcefieldRegressor`` or ``ConservativeForcefieldRegressor``.
+
+    Parameters
+    ----------
+    model : DirectForcefieldRegressor | ConservativeForcefieldRegressor
+        An Orb forcefield model.
+    atoms_adapter : ForcefieldAtomsAdapter
+        The adapter associated with the model, used for cutoff radius and
+        max_num_neighbors metadata.
+    """
+
+    model: _OrbModel
+
+    def __init__(
+        self,
+        model: _OrbModel,
+        atoms_adapter: ForcefieldAtomsAdapter,
+    ) -> None:
+        super().__init__()
+        self.model = model
+        self.atoms_adapter = atoms_adapter
+
+        max_nn = atoms_adapter.max_num_neighbors
+        if max_nn is not None and max_nn < 120:
+            raise ValueError(
+                f"OrbWrapper requires max_num_neighbors >= 120 (got {max_nn}). "
+                f"120 captures all edges under 6 A and is effectively uncapped, "
+                f"which nvalchemi's neighbor list hook assumes."
+            )
+
+        outputs = set(model.properties)
+        supports_pbc = "stress" in outputs
+
+        required_inputs: set[str] = set()
+        optional_inputs = {"cell", "neighbor_list_shifts", "pbc", "charge", "spin"}
+
+        autograd_outputs = model.autograd_derivative_keys & outputs
+        autograd_inputs = frozenset({"positions"}) if autograd_outputs else frozenset()
+
+        self.model_config = ModelConfig(
+            outputs=frozenset(outputs),
+            active_outputs=set(outputs),
+            autograd_outputs=autograd_outputs,
+            autograd_inputs=autograd_inputs,
+            required_inputs=frozenset(required_inputs),
+            optional_inputs=frozenset(optional_inputs),
+            supports_pbc=supports_pbc,
+            needs_pbc=False,
+            neighbor_config=NeighborConfig(
+                cutoff=self.cutoff,
+                format=NeighborListFormat.COO,
+                half_list=False,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # BaseModelMixin properties
+    # ------------------------------------------------------------------
+
+    @property
+    def embedding_shapes(self) -> dict[str, tuple[int, ...]]:
+        latent_dim: int = cast(MoleculeGNS, self.model.model).latent_dim
+        return {
+            "node_embeddings": (latent_dim,),
+        }
+
+    @property
+    def cutoff(self) -> float:
+        """Interaction cutoff in Angstroms, from the atoms adapter."""
+        assert self.atoms_adapter.radius is not None, "radius is not set"
+        return self.atoms_adapter.radius
+
+    # ------------------------------------------------------------------
+    # Input / output adaptation
+    # ------------------------------------------------------------------
+
+    def adapt_input(self, data: AtomicData | Batch, **kwargs: Any) -> AtomGraphs:
+        """Build an Orb ``AtomGraphs`` from a nvalchemi ``Batch``.
+
+        Reuses the neighbor list already computed by nvalchemi's
+        :class:`~nvalchemi.hooks.NeighborListHook` instead of running Orb's
+        own graph construction.
+        """
+        if isinstance(data, AtomicData):
+            data = Batch.from_data_list([data])
+
+        device = data.positions.device
+        dtype = data.positions.dtype
+        B = data.num_graphs
+
+        positions = data.positions
+        atomic_numbers = data.atomic_numbers.long()
+        batch_idx = data.batch_idx.long()
+
+        neighbor_list = data.neighbor_list.long()
+        senders = neighbor_list[:, 0]
+        receivers = neighbor_list[:, 1]
+        E = senders.shape[0]
+
+        neighbor_list_shifts_raw = getattr(data, "neighbor_list_shifts", None)
+        cell_raw = getattr(data, "cell", None)
+
+        if cell_raw is None:
+            cell = (
+                torch.eye(3, dtype=dtype, device=device).unsqueeze(0).expand(B, -1, -1).contiguous()
+            )
+        else:
+            cell = cell_raw.to(dtype=dtype, device=device)
+
+        if neighbor_list_shifts_raw is None:
+            shifts_physical = torch.zeros(E, 3, dtype=dtype, device=device)
+            unit_shifts = torch.zeros(E, 3, dtype=dtype, device=device)
+        else:
+            unit_shifts = neighbor_list_shifts_raw.to(dtype=dtype, device=device)
+            sender_batch = batch_idx[senders]
+            shifts_physical = torch.einsum("eb,ebc->ec", unit_shifts, cell[sender_batch])
+
+        edge_vectors = positions[receivers] - positions[senders] + shifts_physical
+
+        pbc_raw = getattr(data, "pbc", None)
+        if pbc_raw is not None:
+            pbc = pbc_raw.to(device=device)
+            if pbc.dim() == 1:
+                pbc = pbc.unsqueeze(0).expand(B, -1)
+        else:
+            pbc = torch.zeros(B, 3, dtype=torch.bool, device=device)
+
+        atomic_numbers_embedding = torch.nn.functional.one_hot(atomic_numbers, num_classes=118).to(
+            dtype
+        )
+
+        n_node = torch.bincount(batch_idx, minlength=B)
+        sender_batch = batch_idx[senders]
+        n_edge = torch.bincount(sender_batch, minlength=B)
+
+        max_num_neighbors = self.atoms_adapter.max_num_neighbors
+        assert max_num_neighbors is not None, "max_num_neighbors is not set"
+
+        system_features: dict[str, torch.Tensor] = {"cell": cell, "pbc": pbc}
+        charge = getattr(data, "charge", None)
+        if charge is not None:
+            system_features["total_charge"] = charge.to(dtype=dtype, device=device).view(B)
+        spin = getattr(data, "spin", None)
+        if spin is not None:
+            system_features["spin_multiplicity"] = spin.to(dtype=dtype, device=device).view(B)
+
+        return AtomGraphs(
+            senders=senders,
+            receivers=receivers,
+            n_node=n_node,
+            n_edge=n_edge,
+            node_features={
+                "positions": positions,
+                "atomic_numbers": atomic_numbers,
+                "atomic_numbers_embedding": atomic_numbers_embedding,
+            },
+            edge_features={
+                "vectors": edge_vectors,
+                "unit_shifts": unit_shifts,
+            },
+            system_features=system_features,
+            node_targets={},
+            edge_targets={},
+            system_targets={},
+            system_id=None,
+            fix_atoms=None,
+            tags=None,
+            radius=self.cutoff,
+            max_num_neighbors=torch.full_like(n_node, fill_value=max_num_neighbors),
+        )
+
+    def adapt_output(self, raw_output: dict[str, Any], data: AtomicData | Batch) -> ModelOutputs:
+        """Map Orb output dict to nvalchemi :class:`ModelOutputs`.
+
+        Does not call ``super().adapt_output()`` because the base implementation
+        filters by ``active_outputs``, which excludes forces/stress in pipeline
+        autograd mode — even though analytical (non-autograd) derivatives must
+        still pass through.
+        """
+
+        output: ModelOutputs = OrderedDict()
+
+        energy = raw_output.get("energy")
+        if energy is not None:
+            output["energy"] = energy.unsqueeze(-1) if energy.ndim == 1 else energy
+
+        forces = raw_output.get("forces")
+        if forces is not None:
+            output["forces"] = forces
+
+        stress = raw_output.get("stress")
+        if stress is not None:
+            output["stress"] = _voigt_6_to_full_3x3(torch.atleast_2d(stress))
+
+        return output
+
+    # ------------------------------------------------------------------
+    # Forward pass
+    # ------------------------------------------------------------------
+
+    def _is_pipeline_autograd(self) -> bool:
+        """Check if a pipeline has stripped autograd outputs from active_outputs.
+
+        In an autograd group the pipeline removes derivative keys (forces, stress)
+        from active_outputs so it can compute them via its own autograd pass on
+        the summed energy. We detect this by checking that autograd outputs are
+        no longer a subset of active_outputs.
+        """
+        if not self.model_config.autograd_outputs:
+            return False
+        active = self.model_config.active_outputs
+        return "energy" in active and not (self.model_config.autograd_outputs <= active)
+
+    def forward(self, data: AtomicData | Batch, **kwargs: Any) -> ModelOutputs:
+        """Run the Orb model and return nvalchemi-formatted outputs."""
+        atom_graphs = self.adapt_input(data, **kwargs)
+
+        if self._is_pipeline_autograd():
+            raw = self.model.forward(  # type: ignore[operator]
+                atom_graphs,
+                compute_forces=False,
+                compute_stress=False,
+                fp64_energy=True,
+            )
+            out: dict[str, Any] = {"energy": raw["energy"]}
+            # Return analytical derivatives as forces/stress.
+            # The pipeline mode will sum them with autograd derivatives.
+            for key in self.model.analytic_derivative_keys & raw.keys():
+                if "forces" in key:
+                    out["forces"] = out.get("forces", 0) + raw[key]
+                elif "stress" in key:
+                    out["stress"] = out.get("stress", 0) + raw[key]
+            return self.adapt_output(out, data)
+        else:
+            active = self.model_config.active_outputs & self.model_config.outputs
+            raw = self.model.forward(  # type: ignore[operator]
+                atom_graphs,
+                compute_forces="forces" in active,
+                compute_stress="stress" in active,
+                fp64_energy=True,
+            )
+            return self.adapt_output(raw, data)
+
+    # ------------------------------------------------------------------
+    # Embeddings
+    # ------------------------------------------------------------------
+
+    def compute_embeddings(self, data: AtomicData | Batch, **kwargs: Any) -> AtomicData | Batch:
+        if isinstance(data, AtomicData):
+            data = Batch.from_data_list([data])
+
+        atom_graphs = self.adapt_input(data, **kwargs)
+        out = self.model.model(atom_graphs)
+        node_feats = out["node_features"]
+
+        atoms_group = data._atoms_group
+        if atoms_group is not None:
+            atoms_group["node_embeddings"] = node_feats
+        else:
+            data.node_embeddings = node_feats
+
+        return data
+
+    # ------------------------------------------------------------------
+    # Checkpoint loading
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name: str,
+        device: torch.device | str = torch.device("cpu"),
+        *,
+        compile: bool | None = None,
+    ) -> "OrbWrapper":
+        """Load a pretrained Orb model and return an :class:`OrbWrapper`.
+
+        Parameters
+        ----------
+        model_name : str
+            One of: ``"orbmol-v2"``, ``"orbmol-v1-conservative"``,
+            ``"orbmol-v1-direct"``, ``"orb-v3-conservative-20-omat"``,
+            ``"orb-v3-conservative-inf-omat"``, ``"orb-v3-direct-20-omat"``,
+            ``"orb-v3-direct-inf-omat"``, ``"orb-v3-conservative-20-mpa"``,
+            ``"orb-v3-conservative-inf-mpa"``, ``"orb-v3-direct-20-mpa"``,
+            ``"orb-v3-direct-inf-mpa"``, ``"orb-v2"``.
+        device : torch.device | str
+            Target device. Defaults to CPU.
+        compile : bool | None
+            Whether to ``torch.compile`` the model. ``None`` uses the default heuristic.
+        """
+        _LOADERS: dict[str, Any] = {
+            # orbmol-v2 (learnable electrostatics)
+            "orbmol-v2": pretrained.orbmol_v2,
+            # orbmol-v1 models
+            "orb-v3-conservative-omol": pretrained.orb_v3_conservative_omol,
+            "orb-v3-direct-omol": pretrained.orb_v3_direct_omol,
+            # orbmol-v1 model aliases
+            "orbmol-v1-conservative": pretrained.orbmol_v1_conservative,
+            "orbmol-v1-direct": pretrained.orbmol_v1_direct,
+            # most performant orb-v3 omat models
+            "orb-v3-conservative-inf-omat": pretrained.orb_v3_conservative_inf_omat,
+            "orb-v3-direct-inf-omat": pretrained.orb_v3_direct_inf_omat,
+            # less performant orb-v3 mptraj + alexandria models
+            "orb-v3-conservative-inf-mpa": pretrained.orb_v3_conservative_inf_mpa,
+            "orb-v3-direct-inf-mpa": pretrained.orb_v3_direct_inf_mpa,
+        }
+
+        if model_name not in _LOADERS:
+            raise ValueError(f"Unknown model: {model_name!r}. Available: {sorted(_LOADERS)}")
+
+        model, adapter = _LOADERS[model_name](device=device, compile=compile)
+        assert isinstance(adapter, ForcefieldAtomsAdapter)
+        return cls(model=model, atoms_adapter=adapter)

--- a/orb_models/forcefield/inference/orb_nvalchemi.py
+++ b/orb_models/forcefield/inference/orb_nvalchemi.py
@@ -8,15 +8,15 @@ Usage
 -----
 Load a pretrained Orb model::
 
-    from core.forcefield.inference.orb_nvalchemi import OrbWrapper
+    from orb_models.forcefield.inference.orb_nvalchemi import OrbWrapper
     import torch
 
     model = OrbWrapper.from_pretrained("orb-v3-conservative-omol", device=torch.device("cuda"))
 
 Or wrap an already-loaded model::
 
-    from core import interface
-    orb_model, config, adapter = interface.orb_v3_conservative_omol(device="cuda")
+    from orb_models.forcefield import pretrained
+    orb_model, adapter = pretrained.orb_v3_conservative_omol(device="cuda")
     model = OrbWrapper(orb_model, adapter)
 
 Pipeline composition::
@@ -30,10 +30,22 @@ Notes
 -----
 * Conservative models declare ``autograd_outputs`` so they can participate in
   nvalchemi pipeline autograd groups. Direct models do not.
-* Models with a CoulombModule expose analytical spatial forces/stress via
-  ``analytic_derivative_keys``. In pipeline autograd mode these are passed
-  through to the pipeline, which sums them with autograd derivatives.
 * Stress is converted from Orb's Voigt-6 notation to the full 3x3 tensor.
+
+When to compile
+---------------
+``from_pretrained(compile=...)`` compiles the *model*, which is orthogonal to compiling a *pipeline*. Choose by run mode:
+
+* **Pipeline / dynamics (production)** — keep the wrapper **uncompiled** (``compile=False``,
+  the default) and let nvalchemi compile the whole step (``FusedStage.compile()``): neighbor-list
+  rebuild, forward, force/stress autograd, and integrator update all fuse into one graph.
+  See https://nvidia.github.io/nvalchemi-toolkit/modules/dynamics/fused_stage.html#torch-compile-support
+* **Standalone inference** — ``from_pretrained(compile=True)``: forces come from the model's own autograd
+  inside the compiled forward.
+* **Ad-hoc compiled pipeline** — ``torch.compile(pipe)`` over an *uncompiled* wrapper, after
+  ``pipe.eval()``. Fuses just the forward + force/stress autograd (no dynamics loop).
+* **Training** — conservative models must stay uncompiled (``inference=False``): training needs
+  double-backward, which torch.compile does not support.
 """
 
 from collections import OrderedDict
@@ -281,50 +293,17 @@ class OrbWrapper(nn.Module, BaseModelMixin):
     # Forward pass
     # ------------------------------------------------------------------
 
-    def _is_pipeline_autograd(self) -> bool:
-        """Check if a pipeline has stripped autograd outputs from active_outputs.
-
-        In an autograd group the pipeline removes derivative keys (forces, stress)
-        from active_outputs so it can compute them via its own autograd pass on
-        the summed energy. We detect this by checking that autograd outputs are
-        no longer a subset of active_outputs.
-        """
-        if not self.model_config.autograd_outputs:
-            return False
-        active = self.model_config.active_outputs
-        return "energy" in active and not (self.model_config.autograd_outputs <= active)
-
     def forward(self, data: AtomicData | Batch, **kwargs: Any) -> ModelOutputs:
         """Run the Orb model and return nvalchemi-formatted outputs."""
         atom_graphs = self.adapt_input(data, **kwargs)
-
-        if self._is_pipeline_autograd():
-            # Call via __call__ (not .forward) so torch.compile / module hooks apply.
-            raw = self.model(  # type: ignore[operator]
-                atom_graphs,
-                compute_forces=False,
-                compute_stress=False,
-                fp64_energy=True,
-            )
-            out: dict[str, Any] = {"energy": raw["energy"]}
-            # Return analytical derivatives as forces/stress.
-            # The pipeline mode will sum them with autograd derivatives.
-            for key in self.model.analytic_derivative_keys & raw.keys():
-                if "forces" in key:
-                    out["forces"] = out.get("forces", 0) + raw[key]
-                elif "stress" in key:
-                    out["stress"] = out.get("stress", 0) + raw[key]
-            return self.adapt_output(out, data)
-        else:
-            active = self.model_config.active_outputs & self.model_config.outputs
-            # Call via __call__ (not .forward) so torch.compile / module hooks apply.
-            raw = self.model(  # type: ignore[operator]
-                atom_graphs,
-                compute_forces="forces" in active,
-                compute_stress="stress" in active,
-                fp64_energy=True,
-            )
-            return self.adapt_output(raw, data)
+        active = self.model_config.active_outputs & self.model_config.outputs
+        raw = self.model(  # type: ignore[operator]
+            atom_graphs,
+            compute_forces="forces" in active,
+            compute_stress="stress" in active,
+            fp64_energy=True,
+        )
+        return self.adapt_output(raw, data)
 
     # ------------------------------------------------------------------
     # Embeddings
@@ -356,7 +335,8 @@ class OrbWrapper(nn.Module, BaseModelMixin):
         model_name: str,
         device: torch.device | str = torch.device("cpu"),
         *,
-        compile: bool | None = None,
+        compile: bool | None = False,
+        inference: bool = True,
     ) -> "OrbWrapper":
         """Load a pretrained Orb model and return an :class:`OrbWrapper`.
 
@@ -372,7 +352,13 @@ class OrbWrapper(nn.Module, BaseModelMixin):
         device : torch.device | str
             Target device. Defaults to CPU.
         compile : bool | None
-            Whether to ``torch.compile`` the model. ``None`` uses the default heuristic.
+            Whether to ``torch.compile`` the model. ``False`` (default): don't; ``True``: always;
+            ``None``: device-based heuristic (see :func:`should_compile`). See the "When to
+            compile" matrix in the module docstring for which to pick per run mode.
+        inference : bool
+            ``True`` (default): eval mode, frozen params.
+            ``False``: train mode, trainable params.
+
         """
         _LOADERS: dict[str, Any] = {
             # orbmol-v2 (learnable electrostatics)
@@ -394,6 +380,8 @@ class OrbWrapper(nn.Module, BaseModelMixin):
         if model_name not in _LOADERS:
             raise ValueError(f"Unknown model: {model_name!r}. Available: {sorted(_LOADERS)}")
 
-        model, adapter = _LOADERS[model_name](device=device, compile=compile)
+        model, adapter = _LOADERS[model_name](device=device, compile=compile, train=not inference)
         assert isinstance(adapter, ForcefieldAtomsAdapter)
-        return cls(model=model, atoms_adapter=adapter)
+        wrapper = cls(model=model, atoms_adapter=adapter)
+        wrapper.train(not inference)
+        return wrapper

--- a/orb_models/forcefield/inference/orb_nvalchemi.py
+++ b/orb_models/forcefield/inference/orb_nvalchemi.py
@@ -299,7 +299,8 @@ class OrbWrapper(nn.Module, BaseModelMixin):
         atom_graphs = self.adapt_input(data, **kwargs)
 
         if self._is_pipeline_autograd():
-            raw = self.model.forward(  # type: ignore[operator]
+            # Call via __call__ (not .forward) so torch.compile / module hooks apply.
+            raw = self.model(  # type: ignore[operator]
                 atom_graphs,
                 compute_forces=False,
                 compute_stress=False,
@@ -316,7 +317,8 @@ class OrbWrapper(nn.Module, BaseModelMixin):
             return self.adapt_output(out, data)
         else:
             active = self.model_config.active_outputs & self.model_config.outputs
-            raw = self.model.forward(  # type: ignore[operator]
+            # Call via __call__ (not .forward) so torch.compile / module hooks apply.
+            raw = self.model(  # type: ignore[operator]
                 atom_graphs,
                 compute_forces="forces" in active,
                 compute_stress="stress" in active,

--- a/orb_models/forcefield/inference/orb_torchsim.py
+++ b/orb_models/forcefield/inference/orb_torchsim.py
@@ -88,7 +88,7 @@ class OrbTorchSimModel(ModelInterface):
         if "stress" in results and not self._compute_stress:
             results.pop("stress", None)
 
-        return results
+        return {k: v.detach() if hasattr(v, "detach") else v for k, v in results.items()}
 
     def _get_results(self, out: dict[str, torch.Tensor]):
         """Parses the results into a final output dictionary."""

--- a/orb_models/forcefield/models/conservative_regressor.py
+++ b/orb_models/forcefield/models/conservative_regressor.py
@@ -142,20 +142,6 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
             keys.add("stress")
         return frozenset(keys)
 
-    @property
-    def analytic_derivative_keys(self) -> frozenset[str]:
-        """Forward() output keys for spatial derivatives that cannot be computed via autograd.
-
-        Returns the dict keys of analytically computed derivatives (e.g. from Coulomb PME)
-        that are *not* obtained via autograd on the energy, and should be added to the gradient-based forces/stress.
-        """
-        if self.coulomb_module is not None:
-            keys = {"analytic_forces"}
-            if self.has_stress:
-                keys.add("analytic_stress")
-            return frozenset(keys)
-        return frozenset()
-
     def forward(
         self,
         batch: AtomGraphs,
@@ -176,18 +162,18 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
             Components (used by loss and pipeline frameworks):
                 "interaction_energy"  — energy without reference (B,)
                 "rotational_grad"     — equivariance regularisation gradient (B, 3, 3)
-                "analytic_forces"     — non-autograd forces, e.g. Coulomb (N, 3)
-                "analytic_stress"     — non-autograd stress, e.g. Coulomb (B, 6)
         """
         compute_stress = compute_stress and self.has_stress
 
         if compute_forces or compute_stress:
-            vectors, stress_displacement, generator = batch.compute_differentiable_edge_vectors()
-            assert stress_displacement is not None
-            assert generator is not None
-            batch.system_features["stress_displacement"] = stress_displacement
-            batch.system_features["generator"] = generator
-            batch.edge_features["vectors"] = vectors
+            geom = batch.compute_differentiable_edge_vectors()
+            assert geom.stress_displacement is not None
+            assert geom.rotation_generator is not None
+            batch.system_features["stress_displacement"] = geom.stress_displacement
+            batch.system_features["generator"] = geom.rotation_generator
+            batch.edge_features["vectors"] = geom.edge_vectors
+            batch.node_features["strained_positions"] = geom.strained_positions
+            batch.system_features["strained_cell"] = geom.strained_cell
 
         out = self.model(batch)
         node_features = out["node_features"]
@@ -218,13 +204,8 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
 
         if self.coulomb_module is not None:
             assert latent_charges is not None, "CoulombModule requires a LatentChargeHead"
-            coulomb_energy, explicit_forces, explicit_stress = self.coulomb_module(
-                latent_charges, batch, compute_forces=True, compute_stress=self.has_stress
-            )
+            coulomb_energy = self.coulomb_module(latent_charges, batch)
             interaction_energy = interaction_energy + coulomb_energy
-            out["analytic_forces"] = explicit_forces
-            if explicit_stress is not None:
-                out["analytic_stress"] = explicit_stress
 
         out["interaction_energy"] = interaction_energy
         out["energy"] = cast(EnergyHead, self.heads["energy"]).absolute_energy(
@@ -241,11 +222,6 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
                 compute_stress=compute_stress,
                 generator=batch.system_features["generator"],
             )
-
-            if "analytic_forces" in out:
-                forces = forces + out["analytic_forces"]
-            if "analytic_stress" in out:
-                stress = stress + out["analytic_stress"]
 
             if compute_forces:
                 out["forces"] = forces  # eV / A

--- a/orb_models/forcefield/models/coulomb_module.py
+++ b/orb_models/forcefield/models/coulomb_module.py
@@ -10,24 +10,20 @@ from nvalchemiops.torch.interactions.electrostatics import (
 from orb_models.common.atoms.batch.graph_batch import AtomGraphs
 from orb_models.common.atoms.graph_featurization import _compute_neighbor_list_with_fallback
 from orb_models.common.models.segment_ops import aggregate_nodes, segment_sum
-from orb_models.forcefield.models.forcefield_utils import torch_full_3x3_to_voigt_6_stress
 
 COULOMB_CONSTANT = 14.3996  # eV*A/e^2
 
 
 class CoulombModule(torch.nn.Module):
-    """Computes long-range electrostatic energy, forces, and virial from predicted charges.
+    """Computes long-range electrostatic energy from predicted charges.
 
-    Returns per-system energy (E), spatial forces (−∂E/∂r), and spatial virial (−Σ_i r_i ⊗ f_i).
-    Charge-equilibration forces and virial are obtained via autograd through the energy.
-    Spatial forces and virial are zero for non-periodic systems (autograd handles them).
+    Returns per-system energy (E). Forces (−∂E/∂r) and stress (∂E/∂ε) are obtained by the caller via autograd.
 
-    Non-periodic — erf-damped direct Coulomb sum (fully differentiable):
+    Non-periodic — erf-damped direct Coulomb sum:
 
         E = k/2 Σ_{i≠j} q_i q_j erf(r_ij / σ√2) / r_ij
 
-    Periodic — Particle Mesh Ewald via nvalchemiops (explicit forces/virial,
-    surrogate energy for charge gradients):
+    Periodic — Particle Mesh Ewald via nvalchemiops:
 
         E = E_real + E_reciprocal − E_self − E_background
         E_real        = 1/2 Σ_{i≠j} q_i q_j erfc(α r_ij / √2) / r_ij
@@ -60,23 +56,19 @@ class CoulombModule(torch.nn.Module):
         latent_charges: torch.Tensor,
         batch: AtomGraphs,
         *,
-        compute_forces: bool = True,
-        compute_stress: bool = True,
         kwargs: dict[str, Any] = {},
-    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
-        """Compute per-system electrostatic energy, and optionally forces and stress.
+    ) -> torch.Tensor:
+        """Compute per-system electrostatic energy.
 
         For non-periodic systems we use the direct Coulomb sum; for periodic systems we use Particle Mesh Ewald.
 
         Args:
             latent_charges: (n_atoms, 1) predicted charges (must require grad).
-            batch: AtomGraphs batch (positions, cell, pbc read from here).
-            compute_forces: Whether to compute explicit spatial forces.
-            compute_stress: Whether to compute explicit spatial stress (Voigt-6).
+            batch: AtomGraphs batch (strained_positions, strained_cell, pbc read from here).
             kwargs: Additional keyword arguments to _direct_coulomb and _particle_mesh_ewald. (Useful for testing.)
         """
         # Validate kwargs against accepted PME parameters.
-        _valid_pme_kwargs = {"pme_cutoff", "pme_alpha", "pme_mesh_dimensions", "pme_hybrid_forces"}
+        _valid_pme_kwargs = {"pme_cutoff", "pme_alpha", "pme_mesh_dimensions"}
         if kwargs:
             unknown = set(kwargs) - _valid_pme_kwargs
             if unknown:
@@ -85,8 +77,11 @@ class CoulombModule(torch.nn.Module):
                 )
         pme_kwargs = {k: v for k, v in kwargs.items() if k in _valid_pme_kwargs}
 
-        positions = batch.node_features["positions"]
-        cell = batch.system_features["cell"]
+        # The regressor injects strained positions/cell (the strain trick for autograd stress)
+        # only when forces/stress are requested; on the energy-only path they're absent, so we
+        # fall back to the raw positions/cell.
+        positions = batch.node_features.get("strained_positions", batch.node_features["positions"])
+        cell = batch.system_features.get("strained_cell", batch.system_features["cell"])
         pbc = batch.system_features["pbc"]
         latent_charges = latent_charges.squeeze(-1)
 
@@ -97,19 +92,8 @@ class CoulombModule(torch.nn.Module):
         batch_idx = batch.node_batch_index
         n_node = batch.n_node
         n_systems = n_node.shape[0]
-        n_atoms = positions.shape[0]
 
         energy = torch.zeros(n_systems, device=positions.device, dtype=positions.dtype)
-        explicit_forces: torch.Tensor | None = None
-        explicit_virial: torch.Tensor | None = None
-        if compute_forces:
-            explicit_forces = torch.zeros(
-                n_atoms, 3, device=positions.device, dtype=positions.dtype
-            )
-        if compute_stress:
-            explicit_virial = torch.zeros(
-                n_systems, 3, 3, device=positions.device, dtype=positions.dtype
-            )
 
         # Non-periodic systems
         np_sys_idx = is_nonperiodic.nonzero(as_tuple=True)[0]
@@ -137,37 +121,16 @@ class CoulombModule(torch.nn.Module):
             p_batch_idx = torch.repeat_interleave(
                 torch.arange(p_sys_idx.shape[0], device=batch_idx.device), p_n_node
             )
-            p_energy, p_forces, p_virial = self._particle_mesh_ewald(
+            energy[p_sys_idx] = self._particle_mesh_ewald(
                 p_charges,
                 p_positions,
                 p_cell,
                 p_batch_idx,
-                p_sys_idx.shape[0],
                 p_pbc,
-                compute_forces=compute_forces,
-                compute_virial=compute_stress,
                 **pme_kwargs,
             )
-            energy[p_sys_idx] = p_energy
-            if compute_forces:
-                assert explicit_forces is not None
-                p_atom_indices = p_atom_mask.nonzero(as_tuple=True)[0]
-                explicit_forces[p_atom_indices] = p_forces
-            if compute_stress:
-                assert explicit_virial is not None
-                explicit_virial[p_sys_idx] = p_virial
 
-        explicit_stress: torch.Tensor | None = None
-        if explicit_virial is not None:
-            cell_3d = cell.view(-1, 3, 3)
-            volume = torch.linalg.det(cell_3d).abs()
-            stress_3x3 = -explicit_virial / volume.view(-1, 1, 1)
-            stress_3x3 = torch.where(
-                torch.abs(stress_3x3) < 1e10, stress_3x3, torch.zeros_like(stress_3x3)
-            )
-            explicit_stress = torch_full_3x3_to_voigt_6_stress(stress_3x3)
-
-        return energy, explicit_forces, explicit_stress
+        return energy
 
     def _direct_coulomb(
         self,
@@ -211,22 +174,13 @@ class CoulombModule(torch.nn.Module):
         positions: torch.Tensor,
         cell: torch.Tensor,
         batch_idx: torch.Tensor,
-        n_systems: int,
         pbc: torch.Tensor,
         *,
-        compute_forces: bool = True,
-        compute_virial: bool = True,
         pme_cutoff: float | None = None,
         pme_alpha: float | None = None,
         pme_mesh_dimensions: tuple[int, ...] | None = None,
-        pme_hybrid_forces: bool = True,  # Used for testing only.
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Periodic PME with explicit forces, charge gradients, and virial.
-
-        The total force is F_i = −∂E/∂r_i − Σ_j (∂E/∂q_j)(dq_j/dr_i).
-        The returned forces/virial are only the first term (∂E/∂r, direct spatial dependence).
-        The second term (charge equilibration force) is obtained via autograd through the energy
-        and the charge-prediction graph (dq/dr).
+    ) -> torch.Tensor:
+        """Periodic PME energy.
 
         Scales as O(N log N) in total atoms N (real-space is O(N) due to
         erfc cutoff; reciprocal-space is O(N log N) due to FFT on the mesh).
@@ -252,7 +206,7 @@ class CoulombModule(torch.nn.Module):
         # so E = k * sum(q_i*q_j/r) = sum(q_scaled_i * q_scaled_j / r).
         scaled_charges = charges * torch.sqrt(self.coulomb_constant)
 
-        pme_result = _particle_mesh_ewald(
+        per_system_energies = _particle_mesh_ewald(
             positions=positions,
             charges=scaled_charges,
             cell=cell,
@@ -264,35 +218,14 @@ class CoulombModule(torch.nn.Module):
             neighbor_matrix_shifts=neighbor_shift_matrix.to(torch.int32),
             mask_value=positions.shape[0],
             accuracy=self.pme_accuracy,
-            compute_forces=compute_forces,
-            compute_charge_gradients=False,
-            compute_virial=compute_virial,
-            hybrid_forces=pme_hybrid_forces,
+            energy_reduction="system",
         )
-        # PME returns a variable-length tuple: energies, [forces], [virial].
-        pme_outputs = pme_result if isinstance(pme_result, tuple) else (pme_result,)
-        it = iter(pme_outputs)
-        per_atom_energies = next(it)
-        explicit_forces = (
-            next(it).detach().to(positions.dtype) if compute_forces else torch.zeros_like(positions)
-        )
-        explicit_virial = (
-            next(it).detach().to(positions.dtype)
-            if compute_virial
-            else torch.zeros(n_systems, 3, 3, device=positions.device, dtype=positions.dtype)
-        )
-        per_atom_energies = per_atom_energies.to(positions.dtype)
-
-        # Per-system energy
-        energies = segment_sum(per_atom_energies, batch_idx, n_systems)
-        surrogate_energies = energies
-
-        return surrogate_energies, explicit_forces, explicit_virial
+        return per_system_energies.to(positions.dtype)
 
 
 @torch.compiler.disable
 def _particle_mesh_ewald(**kwargs):
-    """Excluded from torch.compile — see "Additional notes" in https://github.com/NVIDIA/nvalchemi-toolkit-ops/pull/53."""
+    # Disable torch.compile due to graph breaks which slow down the operation.
     return particle_mesh_ewald(**kwargs)
 
 

--- a/orb_models/forcefield/models/direct_regressor.py
+++ b/orb_models/forcefield/models/direct_regressor.py
@@ -115,15 +115,6 @@ class DirectForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
         """
         return frozenset()
 
-    @property
-    def analytic_derivative_keys(self) -> frozenset[str]:
-        """Forward() output keys for spatial derivatives that cannot be computed via autograd.
-
-        Direct models predict forces/stress from NN heads, so there are
-        no explicit (analytical) derivative terms to expose.
-        """
-        return frozenset()
-
     def forward(
         self,
         batch: AtomGraphs,

--- a/orb_models/forcefield/models/forcefield_heads.py
+++ b/orb_models/forcefield/models/forcefield_heads.py
@@ -190,7 +190,7 @@ class EnergyHead(ForcefieldHead):
                 kJ/mol resolution against large reference energies. See
                 `absolute_energy` for the precision trade-off.
         """
-        interaction_energy = self.forward(node_features, batch)
+        interaction_energy = self(node_features, batch)
         return self.absolute_energy(interaction_energy, batch, fp64=fp64)
 
     def loss(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "torch>=2.8.0, <3.0.0",
     "dm-tree==0.1.8", # Pinned because of https://github.com/google-deepmind/tree/issues/128
     "tqdm>=4.67.1",
-    "nvalchemi-toolkit-ops[torch]>=0.3.1,<0.4",
+    "nvalchemi-toolkit-ops[torch]>=0.4.1,<0.5",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ CI = "https://github.com/orbital-materials/orb-models/actions"
 dev = [
     "pytest>=8.3.4,<9",
     "pytest-xdist>=3.5",
-    "ruff>=0.10.0",
+    "ruff>=0.15,<0.16",
     "mypy>=1.13",
     "torch_dftd",
     "torch-sim-atomistic>=0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 [project.optional-dependencies]
 torchsim = ["torch-sim-atomistic>=0.6.0"]
 # TODO: replace with pypi version once a version is released with bug fixes
-toolkit = ["nvalchemi-toolkit @ git+https://github.com/NVIDIA/nvalchemi-toolkit@main"]
+alchemi-toolkit = ["nvalchemi-toolkit @ git+https://github.com/NVIDIA/nvalchemi-toolkit@main"]
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -49,6 +49,7 @@ dev = [
     "mypy>=1.13",
     "torch_dftd",
     "torch-sim-atomistic>=0.6.0",
+    "nvalchemi-toolkit @ git+https://github.com/NVIDIA/nvalchemi-toolkit@main",
 ]
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
 
 [project.optional-dependencies]
 torchsim = ["torch-sim-atomistic>=0.6.0"]
+# TODO: replace with pypi version once a version is released with bug fixes
+toolkit = ["nvalchemi-toolkit @ git+https://github.com/NVIDIA/nvalchemi-toolkit@main"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/expensive_tests/test_orb_nvalchemi.py
+++ b/tests/expensive_tests/test_orb_nvalchemi.py
@@ -1,0 +1,179 @@
+import numpy as np
+import pytest
+import torch
+from ase.build import bulk, molecule
+
+nvalchemi = pytest.importorskip("nvalchemi", reason="nvalchemi-toolkit not installed")
+
+from nvalchemi.data import AtomicData, Batch  # noqa: E402
+from nvalchemi.models.pipeline import PipelineGroup, PipelineModelWrapper  # noqa: E402
+
+from orb_models.forcefield.forcefield_adapter import ForcefieldAtomsAdapter  # noqa: E402
+from orb_models.forcefield.inference.calculator import ORBCalculator  # noqa: E402
+from orb_models.forcefield.inference.orb_nvalchemi import OrbWrapper  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_CONSERVATIVE_MODELS = [
+    "orbmol-v2",
+    "orbmol-v1-conservative",
+    "orb-v3-conservative-inf-omat",
+]
+_DIRECT_MODELS = [
+    "orb-v3-direct-omol",
+    "orbmol-v1-direct",
+    "orb-v3-direct-inf-omat",
+]
+
+
+@pytest.fixture(scope="module", params=_CONSERVATIVE_MODELS)
+def conservative_wrapper(request) -> OrbWrapper:
+    return OrbWrapper.from_pretrained(request.param)
+
+
+@pytest.fixture(scope="module", params=_DIRECT_MODELS)
+def direct_wrapper(request) -> OrbWrapper:
+    return OrbWrapper.from_pretrained(request.param)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ase_to_nvalchemi_batch(atoms, adapter: ForcefieldAtomsAdapter) -> Batch:
+    """Build a nvalchemi Batch romrom ASE Atoms."""
+    graph = adapter.from_ase_atoms(atoms)
+    neighbor_list = torch.stack([graph.senders, graph.receivers], dim=-1)
+
+    kwargs: dict = {
+        "positions": graph.node_features["positions"],
+        "atomic_numbers": graph.node_features["atomic_numbers"],
+        "neighbor_list": neighbor_list,
+    }
+
+    cell = graph.system_features.get("cell")
+    if cell is not None:
+        kwargs["cell"] = cell
+    unit_shifts = graph.edge_features.get("unit_shifts")
+    if unit_shifts is not None:
+        kwargs["neighbor_list_shifts"] = unit_shifts
+    pbc = graph.system_features.get("pbc")
+    if pbc is not None:
+        kwargs["pbc"] = pbc
+
+    charge = graph.system_features.get("total_charge")
+    if charge is not None:
+        kwargs["charge"] = charge.reshape(1, 1)
+    spin = graph.system_features.get("spin_multiplicity")
+    if spin is not None:
+        kwargs["spin"] = spin.reshape(1, 1)
+
+    return Batch.from_data_list([AtomicData(**kwargs)])
+
+
+def _voigt_6_from_3x3(s: np.ndarray) -> np.ndarray:
+    """Extract Voigt-6 [xx, yy, zz, yz, xz, xy] from a 3x3 symmetric tensor."""
+    return np.array([s[0, 0], s[1, 1], s[2, 2], s[1, 2], s[0, 2], s[0, 1]])
+
+
+def _nacl_bulk():
+    atoms = bulk("NaCl", "rocksalt", a=5.64, cubic=True)
+    atoms.info["charge"] = 0
+    atoms.info["spin"] = 1
+    # Strain to produce non-trivial forces
+    atoms.positions[0] += [0.1, -0.05, 0.08]
+    return atoms
+
+
+def _h2o():
+    atoms = molecule("H2O")
+    atoms.info["charge"] = 0
+    atoms.info["spin"] = 1
+    return atoms
+
+
+def _compare_standalone_predictions(wrapper: OrbWrapper, atoms, *, atol: float = 1e-5):
+    """Run both OrbWrapper and ORBCalculator on the same atoms and assert matching predictions."""
+    adapter = wrapper.atoms_adapter
+    calc = ORBCalculator(wrapper.model, adapter, device="cpu")
+
+    calc.calculate(atoms)
+    ref_energy = calc.results["energy"]
+    ref_forces = calc.results["forces"]
+    ref_stress = calc.results.get("stress")
+
+    batch = _ase_to_nvalchemi_batch(atoms, adapter)
+    out = wrapper.forward(batch)
+
+    energy = out["energy"].detach().cpu().numpy().squeeze()
+    np.testing.assert_allclose(energy, ref_energy, atol=atol, err_msg="energy mismatch")
+
+    forces = out["forces"].detach().cpu().numpy()
+    np.testing.assert_allclose(forces, ref_forces, atol=atol, err_msg="forces mismatch")
+
+    if ref_stress is not None:
+        stress_3x3 = out["stress"].detach().cpu().numpy().squeeze()
+        stress_voigt = _voigt_6_from_3x3(stress_3x3)
+        np.testing.assert_allclose(stress_voigt, ref_stress, atol=atol, err_msg="stress mismatch")
+
+
+def _compare_pipeline_predictions(wrapper: OrbWrapper, atoms, *, atol: float = 1e-5):
+    """Run standalone vs pipeline autograd and assert matching forces/stress."""
+    adapter = wrapper.atoms_adapter
+
+    ref = wrapper.forward(_ase_to_nvalchemi_batch(atoms, adapter))
+    ref_forces = ref["forces"].detach().cpu().numpy()
+
+    pipe = PipelineModelWrapper(groups=[PipelineGroup(steps=[wrapper], use_autograd=True)])
+    out = pipe.forward(_ase_to_nvalchemi_batch(atoms, adapter))
+
+    np.testing.assert_allclose(
+        out["forces"].detach().cpu().numpy(), ref_forces, atol=atol, err_msg="pipeline forces"
+    )
+
+    has_pbc = hasattr(atoms, "pbc") and np.any(atoms.pbc)
+    ref_stress = ref.get("stress")
+    if ref_stress is not None and has_pbc:
+        ref_voigt = _voigt_6_from_3x3(ref_stress.detach().cpu().numpy().squeeze())
+        out_voigt = _voigt_6_from_3x3(out["stress"].detach().cpu().numpy().squeeze())
+        np.testing.assert_allclose(out_voigt, ref_voigt, atol=atol, err_msg="pipeline stress")
+
+
+# ---------------------------------------------------------------------------
+# Conservative models
+# ---------------------------------------------------------------------------
+
+
+class TestConservativeWrapper:
+    def test_standalone_nacl_bulk(self, conservative_wrapper):
+        _compare_standalone_predictions(conservative_wrapper, _nacl_bulk())
+
+    def test_standalone_h2o(self, conservative_wrapper):
+        _compare_standalone_predictions(conservative_wrapper, _h2o())
+
+    # TODO (Vaidas): Re-enable this test once the bug is fixed.
+    # The bug is in prepare_strain function in nvalchemi. They need to symmetrize the displacement tensor.
+    # Their current implementation is correct for rotationally equivariant models, but not for non-equivariant models.
+    # https://github1s.com/NVIDIA/nvalchemi-toolkit/blob/main/nvalchemi/models/_utils.py#L144-L147
+    @pytest.mark.xfail(reason="Stress comparison fails due to a bug in nvalchemi.")
+    def test_pipeline_autograd_nacl_bulk(self, conservative_wrapper):
+        _compare_pipeline_predictions(conservative_wrapper, _nacl_bulk())
+
+    def test_pipeline_autograd_h2o(self, conservative_wrapper):
+        _compare_pipeline_predictions(conservative_wrapper, _h2o())
+
+
+# ---------------------------------------------------------------------------
+# Direct models
+# ---------------------------------------------------------------------------
+
+
+class TestDirectWrapper:
+    def test_standalone_nacl_bulk(self, direct_wrapper):
+        _compare_standalone_predictions(direct_wrapper, _nacl_bulk())
+
+    def test_standalone_h2o(self, direct_wrapper):
+        _compare_standalone_predictions(direct_wrapper, _h2o())

--- a/tests/expensive_tests/test_orb_nvalchemi.py
+++ b/tests/expensive_tests/test_orb_nvalchemi.py
@@ -154,11 +154,6 @@ class TestConservativeWrapper:
     def test_standalone_h2o(self, conservative_wrapper):
         _compare_standalone_predictions(conservative_wrapper, _h2o())
 
-    # TODO (Vaidas): Re-enable this test once the bug is fixed.
-    # The bug is in prepare_strain function in nvalchemi. They need to symmetrize the displacement tensor.
-    # Their current implementation is correct for rotationally equivariant models, but not for non-equivariant models.
-    # https://github1s.com/NVIDIA/nvalchemi-toolkit/blob/main/nvalchemi/models/_utils.py#L144-L147
-    @pytest.mark.xfail(reason="Stress comparison fails due to a bug in nvalchemi.")
     def test_pipeline_autograd_nacl_bulk(self, conservative_wrapper):
         _compare_pipeline_predictions(conservative_wrapper, _nacl_bulk())
 

--- a/tests/expensive_tests/test_orb_nvalchemi.py
+++ b/tests/expensive_tests/test_orb_nvalchemi.py
@@ -30,12 +30,12 @@ _DIRECT_MODELS = [
 
 @pytest.fixture(scope="module", params=_CONSERVATIVE_MODELS)
 def conservative_wrapper(request) -> OrbWrapper:
-    return OrbWrapper.from_pretrained(request.param)
+    return OrbWrapper.from_pretrained(request.param, compile=True)
 
 
 @pytest.fixture(scope="module", params=_DIRECT_MODELS)
 def direct_wrapper(request) -> OrbWrapper:
-    return OrbWrapper.from_pretrained(request.param)
+    return OrbWrapper.from_pretrained(request.param, compile=True)
 
 
 # ---------------------------------------------------------------------------
@@ -106,7 +106,7 @@ def _compare_standalone_predictions(wrapper: OrbWrapper, atoms, *, atol: float =
     ref_stress = calc.results.get("stress")
 
     batch = _ase_to_nvalchemi_batch(atoms, adapter)
-    out = wrapper.forward(batch)
+    out = wrapper(batch)
 
     energy = out["energy"].detach().cpu().numpy().squeeze()
     np.testing.assert_allclose(energy, ref_energy, atol=atol, err_msg="energy mismatch")
@@ -124,11 +124,12 @@ def _compare_pipeline_predictions(wrapper: OrbWrapper, atoms, *, atol: float = 1
     """Run standalone vs pipeline autograd and assert matching forces/stress."""
     adapter = wrapper.atoms_adapter
 
-    ref = wrapper.forward(_ase_to_nvalchemi_batch(atoms, adapter))
+    ref = wrapper(_ase_to_nvalchemi_batch(atoms, adapter))
     ref_forces = ref["forces"].detach().cpu().numpy()
 
     pipe = PipelineModelWrapper(groups=[PipelineGroup(steps=[wrapper], use_autograd=True)])
-    out = pipe.forward(_ase_to_nvalchemi_batch(atoms, adapter))
+    pipe.eval()
+    out = pipe(_ase_to_nvalchemi_batch(atoms, adapter))
 
     np.testing.assert_allclose(
         out["forces"].detach().cpu().numpy(), ref_forces, atol=atol, err_msg="pipeline forces"
@@ -159,6 +160,13 @@ class TestConservativeWrapper:
 
     def test_pipeline_autograd_h2o(self, conservative_wrapper):
         _compare_pipeline_predictions(conservative_wrapper, _h2o())
+
+    def test_compile_with_training_raises(self):
+        """compile (True or the default) + inference=False on a conservative model raises."""
+        with pytest.raises(AssertionError, match="conservative model in training mode"):
+            OrbWrapper.from_pretrained(
+                "orb-v3-conservative-inf-omat", inference=False, compile=True
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/forcefield/test_coulomb_module.py
+++ b/tests/forcefield/test_coulomb_module.py
@@ -62,14 +62,10 @@ def _make_charge_fn(n_atoms: int, seed: int = 42) -> torch.nn.Module:
     )
 
 
-def _total_forces(
-    energy: torch.Tensor,
-    explicit_forces: torch.Tensor,
-    positions: torch.Tensor,
-) -> torch.Tensor:
-    """Compute total Coulomb forces = explicit + autograd(-dE/dr)."""
-    (autograd_forces,) = torch.autograd.grad(energy.sum(), positions, create_graph=True)
-    return explicit_forces - autograd_forces
+def _autograd_forces(energy: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
+    """Total Coulomb forces F = −∂E/∂r via autograd on the energy."""
+    (grad,) = torch.autograd.grad(energy.sum(), positions, create_graph=True)
+    return -grad
 
 
 def _virial_to_stress(virial: torch.Tensor, cell: torch.Tensor) -> torch.Tensor:
@@ -79,35 +75,22 @@ def _virial_to_stress(virial: torch.Tensor, cell: torch.Tensor) -> torch.Tensor:
     return torch_full_3x3_to_voigt_6_stress(stress_3x3)
 
 
-def _total_stress(
-    energy: torch.Tensor,
-    explicit_stress: torch.Tensor,
-    strain: torch.Tensor,
-    cell: torch.Tensor,
+def _autograd_stress(
+    energy: torch.Tensor, strain: torch.Tensor, cell: torch.Tensor
 ) -> torch.Tensor:
-    """Compute total Coulomb stress = explicit + autograd component."""
-    (autograd_virial,) = torch.autograd.grad(energy.sum(), strain, create_graph=True)
-    autograd_stress = _virial_to_stress(autograd_virial.unsqueeze(0), cell).squeeze(0)
-    return explicit_stress.squeeze(0) - autograd_stress
+    """Total Coulomb stress = ∂E/∂ε / V via autograd, in Voigt-6 notation."""
+    (dEde,) = torch.autograd.grad(energy.sum(), strain, create_graph=True)
+    return _virial_to_stress((-dEde).unsqueeze(0), cell).squeeze(0)
 
 
-def _total_forces_and_stress(
-    energy: torch.Tensor,
-    explicit_forces: torch.Tensor,
-    explicit_stress: torch.Tensor,
-    positions: torch.Tensor,
-    strain: torch.Tensor,
-    cell: torch.Tensor,
-    training: bool = True,
+def _autograd_forces_and_stress(
+    energy: torch.Tensor, positions: torch.Tensor, strain: torch.Tensor, cell: torch.Tensor
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    (autograd_forces, autograd_virial) = torch.autograd.grad(
-        outputs=[energy.sum()],
-        inputs=[positions, strain],
-        create_graph=training,
-        retain_graph=training,
-    )
-    autograd_stress = _virial_to_stress(autograd_virial.unsqueeze(0), cell).squeeze(0)
-    return explicit_forces + autograd_forces, explicit_stress.squeeze(0) + autograd_stress
+    """Total forces and stress from a single backward through the energy."""
+    grad_pos, dEde = torch.autograd.grad(energy.sum(), [positions, strain], create_graph=True)
+    forces = -grad_pos
+    stress = _virial_to_stress((-dEde).unsqueeze(0), cell).squeeze(0)
+    return forces, stress
 
 
 def _apply_strain(
@@ -193,13 +176,11 @@ class TestNonPeriodic:
         charges = torch.randn(n_atoms, 1)
 
         coulomb = CoulombModule(direct_coulomb_erf_damping_sigma=1.0)
-        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
+        energy = coulomb(charges, batch)
 
         assert energy.shape == (2,)
         assert torch.isfinite(energy).all()
         assert energy.abs().sum() > 0
-        assert explicit_forces.shape == (n_atoms, 3)
-        assert explicit_stress.shape == (2, 6)
 
     def test_zero_charges_zero_energy(self):
         batch = _make_batch(_nonperiodic_molecules())
@@ -207,7 +188,7 @@ class TestNonPeriodic:
         charges = torch.zeros(n_atoms, 1)
 
         coulomb = CoulombModule(direct_coulomb_erf_damping_sigma=1.0)
-        energy, _, _ = coulomb(charges, batch)
+        energy = coulomb(charges, batch)
 
         assert (energy.abs() < 1e-10).all()
 
@@ -217,7 +198,7 @@ class TestNonPeriodic:
         charges = torch.tensor([[1.0], [-1.0]])
 
         coulomb = CoulombModule(direct_coulomb_erf_damping_sigma=1.0)
-        energy, _, _ = coulomb(charges, batch)
+        energy = coulomb(charges, batch)
 
         assert energy.item() < 0, "Opposite charges should attract (negative energy)"
 
@@ -227,7 +208,7 @@ class TestNonPeriodic:
         charges = torch.randn(n_atoms, 1, requires_grad=True)
 
         coulomb = CoulombModule(direct_coulomb_erf_damping_sigma=1.0)
-        energy, _, _ = coulomb(charges, batch)
+        energy = coulomb(charges, batch)
 
         grad = torch.autograd.grad(energy.sum(), charges)[0]
         assert grad is not None
@@ -243,8 +224,8 @@ class TestNonPeriodic:
         positions = batch.node_features["positions"]
         positions.requires_grad_(True)
         charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
-        energy, explicit_forces, _ = coulomb(charges, batch)
-        total_f = _total_forces(energy, explicit_forces, positions)
+        energy = coulomb(charges, batch)
+        total_f = _autograd_forces(energy, positions)
 
         # Backprop through total forces to charge model weights
         total_f.sum().backward()
@@ -253,7 +234,7 @@ class TestNonPeriodic:
         assert linear.weight.grad.abs().sum() > 0
 
     def test_total_forces(self):
-        """Total force (explicit + autograd) with q=q(r) matches finite difference.
+        """Total force (autograd −dE/dr) with q=q(r) matches finite difference.
 
         Use double precision to avoid numerical instability in finite difference.
         """
@@ -262,19 +243,17 @@ class TestNonPeriodic:
         charge_fn = _make_charge_fn(n_atoms=3).double()
         coulomb = CoulombModule(direct_coulomb_erf_damping_sigma=1.0)
 
-        # Autograd total forces
         positions = batch.node_features["positions"].double()
         batch.node_features["positions"] = positions
         positions.requires_grad_(True)
         charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
-        energy, explicit_forces, _ = coulomb(charges, batch)
-        forces_auto = _total_forces(energy, explicit_forces, positions)
+        energy = coulomb(charges, batch)
+        forces_auto = _autograd_forces(energy, positions)
 
         def energy_fn(pos):
             batch.node_features["positions"] = pos
             q = charge_fn(pos.unsqueeze(0)).squeeze(0)
-            e, _, _ = coulomb(q, batch)
-            return e.sum()
+            return coulomb(q, batch).sum()
 
         forces_fd = _fd_forces(energy_fn, positions)
         torch.testing.assert_close(forces_auto.detach(), forces_fd, atol=1e-5, rtol=1e-5)
@@ -289,14 +268,11 @@ class TestPeriodic:
         charges = torch.randn(n_atoms, 1)
 
         coulomb = _get_coulomb_module()
-        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
+        energy = coulomb(charges, batch)
 
         assert energy.shape == (2,)
         assert torch.isfinite(energy).all()
-        assert explicit_forces.shape == (n_atoms, 3)
-        assert explicit_stress.shape == (2, 6)
-        assert explicit_forces.abs().sum() > 0
-        assert explicit_stress.abs().sum() > 0
+        assert energy.abs().sum() > 0
 
     def test_opposite_charges_attract(self):
         atoms = ase.Atoms(
@@ -309,7 +285,7 @@ class TestPeriodic:
         charges = torch.tensor([[1.0], [-1.0]])
 
         coulomb = CoulombModule(pme_accuracy=1e-6)
-        energy, _, _ = coulomb(charges, batch)
+        energy = coulomb(charges, batch)
 
         assert energy.item() < 0, "Opposite charges should attract (negative energy)"
 
@@ -323,14 +299,14 @@ class TestPeriodic:
         atoms_np = ase.Atoms("H2O", positions=positions)
         batch_np = _make_batch([atoms_np])
         coulomb = CoulombModule(direct_coulomb_erf_damping_sigma=0.5)
-        e_nonperiodic, _, _ = coulomb(charges_val, batch_np)
+        e_nonperiodic = coulomb(charges_val, batch_np)
 
         # Periodic with increasing box size
         energies = []
         for box_size in [15.0, 25.0, 40.0, 100.0]:
             atoms_p = ase.Atoms("H2O", positions=positions, cell=[box_size] * 3, pbc=True)
             batch_p = _make_batch([atoms_p])
-            e, _, _ = CoulombModule(direct_coulomb_erf_damping_sigma=0.5, pme_accuracy=1e-6)(
+            e = CoulombModule(direct_coulomb_erf_damping_sigma=0.5, pme_accuracy=1e-6)(
                 charges_val, batch_p
             )
             energies.append(e.item())
@@ -346,29 +322,57 @@ class TestPeriodic:
         charges = torch.randn(n_atoms, 1, requires_grad=True)
 
         coulomb = _get_coulomb_module()
-        energy, _, _ = coulomb(charges, batch)
+        energy = coulomb(charges, batch)
 
         grad = torch.autograd.grad(energy.sum(), charges)[0]
         assert grad is not None
         assert grad.abs().sum() > 0
 
-    def test_explicit_stress_nonzero(self):
-        batch = _make_batch(_water_molecules())
+    def test_positions_differentiable_both_modes(self):
+        """dE/dr through the PME energy is nonzero in both train/eval modes."""
+        batch = _make_batch(_water_molecules()[:1])
         n_atoms = batch.node_features["positions"].shape[0]
-        torch.manual_seed(42)
-        charges = torch.randn(n_atoms, 1)
+        for mode in ["train", "eval"]:
+            coulomb = _get_coulomb_module()
+            getattr(coulomb, mode)()
 
-        coulomb = _get_coulomb_module()
-        _, _, explicit_stress = coulomb(charges, batch)
+            positions = batch.node_features["positions"].clone().requires_grad_(True)
+            batch.node_features["positions"] = positions
+            charges = torch.randn(n_atoms, 1, requires_grad=True)
+            energy = coulomb(charges, batch)
 
-        assert explicit_stress.abs().sum() > 0
+            grad = torch.autograd.grad(energy.sum(), positions, retain_graph=True)[0]
+            assert grad is not None and grad.abs().sum() > 0, (
+                f"In {mode} mode, dE/dr should be nonzero (energy is position-differentiable)"
+            )
 
-    def test_spatial_forces(self):
-        """Spatial forces (fixed charges) match finite difference.
+    def test_cell_differentiable_both_modes(self):
+        """dE/dε through the PME energy is nonzero in both train/eval modes."""
+        batch = _make_batch(_water_molecules()[:1])
+        n_atoms = batch.node_features["positions"].shape[0]
+        for mode in ["train", "eval"]:
+            coulomb = _get_coulomb_module()
+            getattr(coulomb, mode)()
 
-        With fixed charges, positions are detached inside PME, so the spatial
-        component lives entirely in explicit_forces (no autograd component).
+            pos = batch.node_features["positions"].clone()
+            cell = batch.system_features["cell"].clone()
+            strain = torch.zeros(3, 3, requires_grad=True)
+            strained_pos, strained_cell = _apply_strain(pos, cell, strain)
+            batch.node_features["positions"] = strained_pos
+            batch.system_features["cell"] = strained_cell
 
+            charges = torch.randn(n_atoms, 1, requires_grad=True)
+            energy = coulomb(charges, batch)
+
+            grad = torch.autograd.grad(energy.sum(), strain, retain_graph=True)[0]
+            assert grad is not None and grad.abs().sum() > 0, (
+                f"In {mode} mode, dE/dε should be nonzero (energy is cell-differentiable)"
+            )
+
+    def test_forces_match_fd_fixed_charges(self):
+        """Forces (fixed charges) match finite difference.
+
+        With fixed charges dq/dr=0, so −dE/dr is the pure spatial force.
         Use double precision to avoid numerical instability in finite difference.
         """
         atoms = ase.Atoms(
@@ -384,24 +388,23 @@ class TestPeriodic:
         charges = torch.tensor([[1.0], [-1.0]], dtype=torch.float64)
         coulomb = CoulombModule(pme_accuracy=1e-6)
 
-        _, explicit_forces, _ = coulomb(charges, batch)
-
-        pos_base = batch.node_features["positions"]
+        positions = batch.node_features["positions"].requires_grad_(True)
+        batch.node_features["positions"] = positions
+        forces_auto = _autograd_forces(coulomb(charges, batch), positions)
 
         def force_energy_fn(pos):
             batch.node_features["positions"] = pos
-            e, _, _ = coulomb(charges, batch)
-            return e.sum()
+            return coulomb(charges, batch).sum()
 
-        forces_fd = _fd_forces(force_energy_fn, pos_base)
-        torch.testing.assert_close(explicit_forces, forces_fd, atol=1e-5, rtol=1e-5)
+        forces_fd = _fd_forces(force_energy_fn, positions)
+        torch.testing.assert_close(forces_auto.detach(), forces_fd, atol=1e-5, rtol=1e-5)
 
-    def test_spatial_stress(self):
-        """Spatial stress (fixed charges) matches finite difference.
+    def test_stress_match_fd_fixed_charges(self):
+        """Stress (fixed charges) matches finite difference.
 
-        With fixed charges, positions are detached inside PME, so the spatial
-        component lives entirely in explicit_stress (no autograd component).
-
+        Pin PME parameters so FD strain perturbations don't re-estimate them (a strained
+        cell changes the volume and thus alpha/cutoff, which would make the energy
+        non-smooth w.r.t. strain).
         Use double precision to avoid numerical instability in finite difference.
         """
         atoms = ase.Atoms(
@@ -412,60 +415,26 @@ class TestPeriodic:
         )
 
         batch = _make_batch([atoms])
-        batch.node_features["positions"] = batch.node_features["positions"].double()
-        batch.system_features["cell"] = batch.system_features["cell"].double()
+        pos_base = batch.node_features["positions"].double()
+        cell_base = batch.system_features["cell"].double()
+        batch.node_features["positions"] = pos_base
+        batch.system_features["cell"] = cell_base
         charges = torch.tensor([[1.0], [-1.0]], dtype=torch.float64)
         coulomb = CoulombModule(pme_accuracy=1e-6)
 
-        _, _, explicit_stress = coulomb(charges, batch)
-
-        pos_base = batch.node_features["positions"]
-        cell_base = batch.system_features["cell"]
+        strain = torch.zeros(3, 3, dtype=torch.float64, requires_grad=True)
+        strained_pos, strained_cell = _apply_strain(pos_base, cell_base, strain)
+        batch.node_features["positions"] = strained_pos
+        batch.system_features["cell"] = strained_cell
+        stress_auto = _autograd_stress(coulomb(charges, batch), strain, strained_cell)
 
         def virial_energy_fn(pos, cell):
             batch.node_features["positions"] = pos
             batch.system_features["cell"] = cell
-            e, _, _ = coulomb(charges, batch)
-            return e.sum()
+            return coulomb(charges, batch).sum()
 
         stress_fd = _fd_stress(virial_energy_fn, pos_base, cell_base)
-        torch.testing.assert_close(explicit_stress.squeeze(0), stress_fd, atol=1e-5, rtol=1e-5)
-
-    def test_spatial_forces_not_differentiable_wrt_charges_model(self):
-        """Explicit forces are *not* differentiable w.r.t. charge model."""
-        batch = _make_batch(_water_molecules()[:1])
-        n_atoms = batch.node_features["positions"].shape[0]
-        charge_fn = _make_charge_fn(n_atoms=n_atoms)
-        charge_fn.train()
-        coulomb = _get_coulomb_module()
-        coulomb.train()
-
-        positions = batch.node_features["positions"].clone().requires_grad_(True)
-        batch.node_features["positions"] = positions
-        charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
-        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
-
-        assert explicit_forces.requires_grad is False, (
-            "explicit_forces should not be differentiable"
-        )
-
-    def test_spatial_stress_not_differentiable_wrt_charges_model(self):
-        """Explicit stress is *not* differentiable w.r.t. charge model."""
-        batch = _make_batch(_water_molecules()[:1])
-        n_atoms = batch.node_features["positions"].shape[0]
-        charge_fn = _make_charge_fn(n_atoms=n_atoms)
-        charge_fn.train()
-        coulomb = _get_coulomb_module()
-        coulomb.train()
-
-        positions = batch.node_features["positions"].clone().requires_grad_(True)
-        batch.node_features["positions"] = positions
-        charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
-        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
-
-        assert explicit_stress.requires_grad is False, (
-            "explicit_stress should not be differentiable"
-        )
+        torch.testing.assert_close(stress_auto.detach(), stress_fd, atol=1e-5, rtol=1e-5)
 
     def test_total_forces_differentiable_wrt_charges_model(self):
         """Total forces are differentiable w.r.t. charge model."""
@@ -479,9 +448,9 @@ class TestPeriodic:
         positions = batch.node_features["positions"].clone().requires_grad_(True)
         batch.node_features["positions"] = positions
         charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
-        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
+        energy = coulomb(charges, batch)
 
-        total_forces = _total_forces(energy, explicit_forces, positions)
+        total_forces = _autograd_forces(energy, positions)
 
         linear = charge_fn[1]
         total_forces.sum().backward()
@@ -508,9 +477,9 @@ class TestPeriodic:
         batch.system_features["cell"] = strained_cell
 
         charges = charge_fn(strained_pos.unsqueeze(0)).squeeze(0)
-        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
+        energy = coulomb(charges, batch)
 
-        total_stress = _total_stress(energy, explicit_stress, strain, strained_cell)
+        total_stress = _autograd_stress(energy, strain, strained_cell)
 
         linear = charge_fn[1]
         total_stress.sum().backward()
@@ -520,7 +489,7 @@ class TestPeriodic:
         assert linear.weight.grad.abs().sum() > 0
 
     def test_combined_loss_differentiable_wrt_charges_model(self):
-        """Combined loss on energy, total forces, and total virial is differentiable w.r.t. charge model.
+        """Combined loss on energy, total forces, and total stress is differentiable w.r.t. charge model.
 
         This is mostly just a smoke test to ensure that this works.
         """
@@ -534,7 +503,6 @@ class TestPeriodic:
         pos_base = batch.node_features["positions"].clone()
         cell_base = batch.system_features["cell"]
 
-        # Apply differentiable strain for virial
         strain = torch.zeros(3, 3, dtype=pos_base.dtype, requires_grad=True)
         strained_pos, strained_cell = _apply_strain(pos_base, cell_base, strain)
         positions = strained_pos.requires_grad_(True)
@@ -542,16 +510,10 @@ class TestPeriodic:
         batch.system_features["cell"] = strained_cell
 
         charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
-        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
+        energy = coulomb(charges, batch)
 
-        total_forces, total_stress = _total_forces_and_stress(
-            energy,
-            explicit_forces,
-            explicit_stress,
-            positions,
-            strain,
-            strained_cell,
-            training=True,
+        total_forces, total_stress = _autograd_forces_and_stress(
+            energy, positions, strain, strained_cell
         )
 
         linear = charge_fn[1]
@@ -578,7 +540,7 @@ class TestPeriodic:
         positions = batch.node_features["positions"]
         positions.requires_grad_(True)
         charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
-        energy, _, _ = coulomb(charges, batch)
+        energy = coulomb(charges, batch)
 
         # dE/dq should be nonzero
         dEdq = torch.autograd.grad(energy.sum(), charges, retain_graph=True)[0]
@@ -608,14 +570,13 @@ class TestPeriodic:
         positions = batch.node_features["positions"]
         positions.requires_grad_(True)
         charges = charge_fn(positions.unsqueeze(0)).squeeze(0)
-        energy, explicit_forces, _ = coulomb(charges, batch)
-        forces_auto = _total_forces(energy, explicit_forces, positions)
+        energy = coulomb(charges, batch)
+        forces_auto = _autograd_forces(energy, positions)
 
         def energy_fn(pos):
             batch.node_features["positions"] = pos
             q = charge_fn(pos.unsqueeze(0)).squeeze(0)
-            e, _, _ = coulomb(q, batch)
-            return e.sum()
+            return coulomb(q, batch).sum()
 
         forces_fd = _fd_forces(energy_fn, positions)
         torch.testing.assert_close(forces_auto.detach(), forces_fd, atol=1e-5, rtol=1e-5)
@@ -663,83 +624,17 @@ class TestPeriodic:
         batch.system_features["cell"] = strained_cell
 
         charges = charge_fn(strained_pos.unsqueeze(0)).squeeze(0)
-        energy, _, explicit_stress = coulomb(charges, batch, kwargs=fixed_pme)
-        stress_auto = _total_stress(energy, explicit_stress, strain, strained_cell)
+        energy = coulomb(charges, batch, kwargs=fixed_pme)
+        stress_auto = _autograd_stress(energy, strain, strained_cell)
 
         def virial_energy_fn(pos, cell):
             batch.node_features["positions"] = pos
             batch.system_features["cell"] = cell
             q = charge_fn(pos.unsqueeze(0)).squeeze(0)
-            e, _, _ = coulomb(q, batch, kwargs=fixed_pme)
-            return e.sum()
+            return coulomb(q, batch, kwargs=fixed_pme).sum()
 
         stress_fd = _fd_stress(virial_energy_fn, pos_base, cell_base)
         torch.testing.assert_close(stress_auto.detach(), stress_fd, atol=1e-5, rtol=1e-5)
-
-    def test_positions_detached_both_modes(self):
-        """Positions are detached inside PME in both train/eval modes.
-
-        Spatial forces come only from explicit_forces, not through autograd on energy.
-        """
-        batch = _make_batch(_water_molecules()[:1])
-        n_atoms = batch.node_features["positions"].shape[0]
-        for mode in ["train", "eval"]:
-            coulomb = _get_coulomb_module()
-            getattr(coulomb, mode)()
-
-            positions = batch.node_features["positions"].clone().requires_grad_(True)
-            batch.node_features["positions"] = positions
-            # Charges require grad so the energy stays in the compute graph
-            charges = torch.randn(n_atoms, 1, requires_grad=True)
-            energy, explicit_forces, _ = coulomb(charges, batch)
-
-            # dE/dr through the energy should be None (positions detached inside PME)
-            grad = torch.autograd.grad(
-                energy.sum(), positions, allow_unused=True, retain_graph=True
-            )[0]
-            assert grad is None or (grad.abs() < 1e-10).all(), (
-                f"In {mode} mode, positions should be detached inside PME"
-            )
-
-            # But explicit_forces should be nonzero
-            assert explicit_forces.abs().sum() > 0, (
-                f"In {mode} mode, explicit_forces should carry the spatial component"
-            )
-
-    def test_cell_detached_both_modes(self):
-        """Cell is detached inside PME in both train/eval modes.
-
-        Stress contributions come only from explicit_stress, not through autograd
-        on energy w.r.t. strain.
-        """
-        batch = _make_batch(_water_molecules()[:1])
-        n_atoms = batch.node_features["positions"].shape[0]
-        for mode in ["train", "eval"]:
-            coulomb = _get_coulomb_module()
-            getattr(coulomb, mode)()
-
-            pos = batch.node_features["positions"].clone()
-            cell = batch.system_features["cell"].clone()
-            strain = torch.zeros(3, 3, requires_grad=True)
-            strained_pos, strained_cell = _apply_strain(pos, cell, strain)
-            batch.node_features["positions"] = strained_pos
-            batch.system_features["cell"] = strained_cell
-
-            charges = torch.randn(n_atoms, 1, requires_grad=True)
-            energy, _, explicit_stress = coulomb(charges, batch)
-
-            # dE/dε through the energy should be None (cell detached inside PME)
-            grad = torch.autograd.grad(energy.sum(), strain, allow_unused=True, retain_graph=True)[
-                0
-            ]
-            assert grad is None or (grad.abs() < 1e-10).all(), (
-                f"In {mode} mode, cell should be detached inside PME"
-            )
-
-            # But explicit_stress should be nonzero
-            assert explicit_stress.abs().sum() > 0, (
-                f"In {mode} mode, explicit_stress should carry the stress component"
-            )
 
 
 class TestBatching:
@@ -755,12 +650,12 @@ class TestBatching:
             n = len(mol)
             q = torch.randn(n, 1)
             all_charges.append(q)
-            e, _, _ = coulomb(q, _make_batch([mol]))
+            e = coulomb(q, _make_batch([mol]))
             individual_energies.append(e.item())
 
         batch = _make_batch(molecules)
         charges = torch.cat(all_charges, dim=0)
-        batched_energies, _, _ = coulomb(charges, batch)
+        batched_energies = coulomb(charges, batch)
 
         for i, (batched, individual) in enumerate(
             zip(batched_energies.tolist(), individual_energies, strict=True)
@@ -770,7 +665,7 @@ class TestBatching:
             )
 
     def test_periodic_batched_vs_individual(self):
-        """Energy, explicit_forces, and stress match between batched and individual."""
+        """Energy, forces, and stress match between batched and individual."""
         waters = _water_molecules()
         coulomb = _get_coulomb_module()
 
@@ -782,14 +677,41 @@ class TestBatching:
             n = len(mol)
             q = torch.randn(n, 1)
             all_charges.append(q)
-            e, f, v = coulomb(q, _make_batch([mol]))
+
+            single = _make_batch([mol])
+            pos = single.node_features["positions"].double().requires_grad_(True)
+            single.node_features["positions"] = pos
+            cell_base = single.system_features["cell"].double()
+            strain = torch.zeros(3, 3, dtype=torch.float64, requires_grad=True)
+            strained_pos, strained_cell = _apply_strain(pos, cell_base, strain)
+            single.node_features["positions"] = strained_pos
+            single.system_features["cell"] = strained_cell
+            e = coulomb(q.double(), single)
             individual_energies.append(e.item())
-            individual_forces.append(f)
-            individual_stresses.append(v)
+            f, s = _autograd_forces_and_stress(e, pos, strain, strained_cell)
+            individual_forces.append(f.detach())
+            individual_stresses.append(s.detach())
 
         batch = _make_batch(waters)
-        charges = torch.cat(all_charges, dim=0)
-        batched_energies, batched_forces, batched_stress = coulomb(charges, batch)
+        charges = torch.cat(all_charges, dim=0).double()
+        pos = batch.node_features["positions"].double().requires_grad_(True)
+        batch.node_features["positions"] = pos
+        cell_base = batch.system_features["cell"].double()
+        # Per-system independent strains, so each system's stress is recoverable.
+        strain = torch.zeros(len(waters), 3, 3, dtype=torch.float64, requires_grad=True)
+        node_graph_idx = batch.node_batch_index
+        sym = 0.5 * (strain + strain.transpose(-1, -2))
+        strained_pos = pos + torch.bmm(pos.unsqueeze(1), sym[node_graph_idx]).squeeze(1)
+        strained_cell = cell_base + torch.bmm(cell_base, sym)
+        batch.node_features["positions"] = strained_pos
+        batch.system_features["cell"] = strained_cell
+        batched_energies = coulomb(charges, batch)
+        # Single backward for both forces and stress (per-system strain, so no unsqueeze).
+        grad_pos, dEde = torch.autograd.grad(
+            batched_energies.sum(), [pos, strain], create_graph=True
+        )
+        batched_forces = (-grad_pos).detach()
+        batched_stress = _virial_to_stress(-dEde, strained_cell).detach()
 
         # Energy
         for i, (batched, individual) in enumerate(
@@ -814,14 +736,14 @@ class TestBatching:
         # Stress
         for i in range(len(waters)):
             torch.testing.assert_close(
-                batched_stress[i : i + 1],
+                batched_stress[i],
                 individual_stresses[i],
                 atol=1e-3,
                 rtol=1e-3,
             )
 
     def test_mixed_periodic_nonperiodic(self):
-        """Mixed batch: each system matches its individual computation."""
+        """Mixed batch: each system's energy and forces match its individual computation."""
         periodic = ase.Atoms(
             "H2O",
             positions=[[0, 0, 0], [0.96, 0, 0], [0.24, 0.93, 0]],
@@ -835,21 +757,17 @@ class TestBatching:
         q_periodic = torch.randn(3, 1)
         q_nonperiodic = torch.randn(2, 1)
 
-        e_periodic, f_periodic, _ = coulomb(q_periodic, _make_batch([periodic]))
-        e_nonperiodic, f_nonperiodic, _ = coulomb(q_nonperiodic, _make_batch([nonperiodic]))
+        e_periodic = coulomb(q_periodic, _make_batch([periodic]))
+        e_nonperiodic = coulomb(q_nonperiodic, _make_batch([nonperiodic]))
 
         # Mixed batch
         mixed_batch = _make_batch([periodic, nonperiodic])
         mixed_charges = torch.cat([q_periodic, q_nonperiodic], dim=0)
-        mixed_energy, mixed_forces, _ = coulomb(mixed_charges, mixed_batch)
+        mixed_energy = coulomb(mixed_charges, mixed_batch)
 
         assert mixed_energy.shape == (2,)
         torch.testing.assert_close(mixed_energy[0], e_periodic[0], atol=1e-4, rtol=1e-4)
         torch.testing.assert_close(mixed_energy[1], e_nonperiodic[0], atol=1e-5, rtol=1e-5)
-
-        # Non-periodic explicit forces should be zero, periodic should be nonzero
-        assert mixed_forces[:3].abs().sum() > 0, "Periodic explicit forces should be nonzero"
-        assert (mixed_forces[3:].abs() < 1e-10).all(), "Non-periodic explicit forces should be zero"
 
 
 class TestRotationalGradients:
@@ -863,11 +781,8 @@ class TestRotationalGradients:
     def test_rotational_grad_zero_with_fixed_charges(self, atoms_fn):
         """dE/d(generator) is zero when charges are independent of geometry.
 
-        Sanity check to ensure that we're not missing a contribution to equigrad gradients,
-        since nvalchemiops detaches positions and cell from the graph.
-
-        Coulomb energy is rotationally invariant, so rotating positions (and cell)
-        via the generator should not change energy — gradient must vanish.
+        Coulomb energy is rotationally invariant, so jointly rotating positions (and cell)
+        via the generator must not change the energy — the gradient vanishes.
         """
         batch = _make_batch(atoms_fn())
         n_atoms = batch.node_features["positions"].shape[0]
@@ -884,17 +799,10 @@ class TestRotationalGradients:
             batch.system_features["cell"] = cell @ rotation
 
         charges = torch.randn(n_atoms, 1, requires_grad=True)
-        # For this test, we disable hybrid forces, so that nvalchemiops does not detach positions and cell from the graph.
-        # This allows us to check that the rotational gradient is zero when charges are fixed.
-        # We do this because our normal computation graph with hybrid_forces=True would detach the positions and cell
-        # from the graph _and also_ compute_differentiable_edge_vectors does not set the rotated positions/cell in the AtomGraphs object,
-        # hence their contributions to equigrad regularization would be lost.
-        #
-        # This check tests that we are not missing anything (rotational gradients are 0)
-        energy, _, _ = coulomb(charges, batch, kwargs={"pme_hybrid_forces": False})
+        energy = coulomb(charges, batch)
 
         grad = torch.autograd.grad(energy.sum(), generator, allow_unused=True, retain_graph=True)[0]
-        assert (grad.abs() < 1e-7).all(), (
+        assert grad is None or (grad.abs() < 1e-7).all(), (
             f"Rotational gradient should be zero with fixed charges, got {grad}"
         )
 
@@ -925,7 +833,7 @@ class TestRotationalGradients:
             batch.system_features["cell"] = cell @ rotation
 
         charges = charge_fn(rotated_pos.unsqueeze(0)).squeeze(0)
-        energy, _, _ = coulomb(charges, batch)
+        energy = coulomb(charges, batch)
 
         grad = torch.autograd.grad(energy.sum(), generator)[0]
         assert grad.abs().sum() > 0.5, (
@@ -987,14 +895,14 @@ class TestEdgeCases:
         batch_np = _make_batch([atoms_np])
         charges = torch.tensor([[1.0]])
         coulomb = _get_coulomb_module()
-        energy, _, _ = coulomb(charges, batch_np)
+        energy = coulomb(charges, batch_np)
         assert energy.item() == pytest.approx(0.0, abs=1e-6)
 
         # Periodic: finite energy
         atoms_p = ase.Atoms("H", positions=[[0, 0, 0]], cell=[10, 10, 10], pbc=True)
         batch_p = _make_batch([atoms_p])
         coulomb_p = _get_coulomb_module()
-        energy_p, _, _ = coulomb_p(charges, batch_p)
+        energy_p = coulomb_p(charges, batch_p)
         assert torch.isfinite(energy_p).all()
 
     def test_mixed_system_sizes(self):
@@ -1008,11 +916,9 @@ class TestEdgeCases:
         charges = torch.randn(n_atoms, 1)
 
         coulomb = _get_coulomb_module()
-        energy, explicit_forces, explicit_stress = coulomb(charges, batch)
+        energy = coulomb(charges, batch)
 
         assert energy.shape == (3,)
-        assert explicit_forces.shape == (n_atoms, 3)
-        assert explicit_stress.shape == (3, 6)
         assert torch.isfinite(energy).all()
 
     def test_partial_pbc_raises(self):

--- a/tests/forcefield/test_forcefield_adapter.py
+++ b/tests/forcefield/test_forcefield_adapter.py
@@ -88,7 +88,8 @@ def test_forcefield_adapter_equigrad():
     graphs_ = []
     for atoms in [periodic, molecule]:
         g = adapter.from_ase_atoms(atoms)
-        vectors, _, generator = g.compute_differentiable_edge_vectors()
+        geom = g.compute_differentiable_edge_vectors()
+        vectors, generator = geom.edge_vectors, geom.rotation_generator
         g.edge_features["vectors"] = vectors
         g.system_features["generator"] = generator
         graphs.append(g)

--- a/tests/forcefield/test_forcefield_heads.py
+++ b/tests/forcefield/test_forcefield_heads.py
@@ -38,7 +38,7 @@ def test_linear_reference_energy_forward_zero_weights():
     model = LinearReferenceEnergy(weight_init=weight_init, trainable=False)
     atom_types = torch.tensor([1, 6, 8, 1, 1], dtype=torch.long)
     n_node = torch.tensor([5])
-    output = model.forward(atom_types, n_node)
+    output = model(atom_types, n_node)
     expected_output = torch.zeros((1, 1))
     assert torch.allclose(output, expected_output)
 
@@ -48,7 +48,7 @@ def test_linear_reference_energy_forward_one_weights():
     model = LinearReferenceEnergy(weight_init=weight_init, trainable=False)
     atom_types = torch.tensor([1, 6, 8, 1, 1], dtype=torch.long)
     n_node = torch.tensor([5])
-    output = model.forward(atom_types, n_node)
+    output = model(atom_types, n_node)
     expected_output = torch.tensor([[5.0]])
     assert torch.allclose(output, expected_output)
 
@@ -63,7 +63,7 @@ def test_energy_head_initialization(energy_head):
 
 def test_energy_head_forward(energy_head, batch):
     node_features = batch.node_features[_KEY]
-    output = energy_head.forward(node_features, batch)
+    output = energy_head(node_features, batch)
     assert output.shape == (batch.n_node.shape[0],)
 
 
@@ -125,7 +125,7 @@ def test_force_head_initialization(force_head):
 
 def test_force_head_forward(force_head, batch):
     node_features = batch.node_features[_KEY]
-    output = force_head.forward(node_features, batch)
+    output = force_head(node_features, batch)
     assert output.shape == (batch.n_node.sum().item(), 3)
 
 

--- a/tests/forcefield/test_orb_nvalchemi.py
+++ b/tests/forcefield/test_orb_nvalchemi.py
@@ -263,116 +263,90 @@ class TestAdaptOutput:
 
 class TestForwardDirect:
     def test_energy_shape_single(self, direct_wrapper, single_batch):
-        out = direct_wrapper.forward(single_batch)
+        out = direct_wrapper(single_batch)
         assert out["energy"].shape == (1, 1)
 
     def test_energy_shape_multi(self, direct_wrapper, multi_batch):
-        out = direct_wrapper.forward(multi_batch)
+        out = direct_wrapper(multi_batch)
         assert out["energy"].shape == (2, 1)
 
     def test_forces_shape(self, direct_wrapper, single_batch):
-        out = direct_wrapper.forward(single_batch)
+        out = direct_wrapper(single_batch)
         assert out["forces"].shape == (3, 3)
 
     def test_forces_shape_multi(self, direct_wrapper, multi_batch):
-        out = direct_wrapper.forward(multi_batch)
+        out = direct_wrapper(multi_batch)
         assert out["forces"].shape == (6, 3)
 
     def test_stress_shape(self, direct_wrapper, single_batch):
-        out = direct_wrapper.forward(single_batch)
+        out = direct_wrapper(single_batch)
         assert out["stress"].shape == (1, 3, 3)
 
     def test_stress_shape_multi(self, direct_wrapper, multi_batch):
-        out = direct_wrapper.forward(multi_batch)
+        out = direct_wrapper(multi_batch)
         assert out["stress"].shape == (2, 3, 3)
 
     def test_no_forces_when_disabled(self, direct_wrapper, single_batch):
         direct_wrapper.model_config.active_outputs = {"energy"}
-        out = direct_wrapper.forward(single_batch)
+        out = direct_wrapper(single_batch)
         assert out.get("forces") is None
 
     def test_no_stress_when_disabled(self, direct_wrapper, single_batch):
         direct_wrapper.model_config.active_outputs = {"energy", "forces"}
-        out = direct_wrapper.forward(single_batch)
+        out = direct_wrapper(single_batch)
         assert out.get("stress") is None
 
 
 class TestForwardConservative:
     def test_energy_shape_single(self, conservative_wrapper, single_batch):
-        out = conservative_wrapper.forward(single_batch)
+        out = conservative_wrapper(single_batch)
         assert out["energy"].shape == (1, 1)
 
     def test_energy_shape_multi(self, conservative_wrapper, multi_batch):
-        out = conservative_wrapper.forward(multi_batch)
+        out = conservative_wrapper(multi_batch)
         assert out["energy"].shape == (2, 1)
 
     def test_forces_shape(self, conservative_wrapper, single_batch):
-        out = conservative_wrapper.forward(single_batch)
+        out = conservative_wrapper(single_batch)
         assert out["forces"].shape == (3, 3)
 
     def test_forces_shape_multi(self, conservative_wrapper, multi_batch):
-        out = conservative_wrapper.forward(multi_batch)
+        out = conservative_wrapper(multi_batch)
         assert out["forces"].shape == (6, 3)
 
     def test_stress_shape(self, conservative_wrapper, single_batch):
-        out = conservative_wrapper.forward(single_batch)
+        out = conservative_wrapper(single_batch)
         assert out["stress"].shape == (1, 3, 3)
 
     def test_no_forces_when_disabled(self, conservative_wrapper, single_batch):
         conservative_wrapper.model_config.active_outputs = {"energy"}
-        out = conservative_wrapper.forward(single_batch)
+        out = conservative_wrapper(single_batch)
         assert out.get("forces") is None
 
     def test_no_stress_when_disabled(self, conservative_wrapper, single_batch):
         conservative_wrapper.model_config.active_outputs = {"energy", "forces"}
-        out = conservative_wrapper.forward(single_batch)
+        out = conservative_wrapper(single_batch)
         assert out.get("stress") is None
 
 
-class TestPipelineAutograd:
-    def test_not_pipeline_autograd_by_default(self, conservative_wrapper):
-        assert not conservative_wrapper._is_pipeline_autograd()
-
-    def test_direct_never_pipeline_autograd(self, direct_wrapper):
-        direct_wrapper.model_config.active_outputs = {"energy"}
-        assert not direct_wrapper._is_pipeline_autograd()
-
-    def test_is_pipeline_autograd_when_derivatives_stripped(self, conservative_wrapper):
+class TestPipeline:
+    def test_pipeline_returns_energy_only(self, conservative_wrapper, single_batch):
         conservative_wrapper.model_config.active_outputs = {"energy"}
-        assert conservative_wrapper._is_pipeline_autograd()
+        out = conservative_wrapper(single_batch)
+        assert "energy" in out
+        assert "forces" not in out
+        assert "stress" not in out
 
-    def test_pipeline_autograd_returns_energy(self, conservative_wrapper, single_batch):
+    def test_pipeline_does_not_mutate_active_outputs(self, conservative_wrapper, single_batch):
         conservative_wrapper.model_config.active_outputs = {"energy"}
-        out = conservative_wrapper.forward(single_batch)
-        assert out["energy"] is not None
+        conservative_wrapper(single_batch)
+        assert conservative_wrapper.model_config.active_outputs == {"energy"}
 
     def test_direct_derivative_keys_conservative(self, conservative_wrapper):
         assert conservative_wrapper.direct_derivative_keys() == set()
 
     def test_direct_derivative_keys_direct(self, direct_wrapper):
         assert direct_wrapper.direct_derivative_keys() == set()
-
-
-class TestPipelineAnalyticDerivatives:
-    @pytest.fixture
-    def wrapper(self, adapter):
-        model = orb_v3_conservative_architecture(latent_dim=_LATENT_DIM, has_electrostatics=True)
-        return OrbWrapper(model, adapter)
-
-    def test_pipeline_autograd_returns_analytic_forces(self, wrapper, single_batch):
-        wrapper.model_config.active_outputs = {"energy"}
-        out = wrapper.forward(single_batch)
-        assert out["forces"].shape == (3, 3)
-
-    def test_pipeline_autograd_returns_analytic_stress(self, wrapper, single_batch):
-        wrapper.model_config.active_outputs = {"energy"}
-        out = wrapper.forward(single_batch)
-        assert out["stress"].shape == (1, 3, 3)
-
-    def test_pipeline_autograd_does_not_mutate_active_outputs(self, wrapper, single_batch):
-        wrapper.model_config.active_outputs = {"energy"}
-        wrapper.forward(single_batch)
-        assert wrapper.model_config.active_outputs == {"energy"}
 
 
 class TestComputeEmbeddings:

--- a/tests/forcefield/test_orb_nvalchemi.py
+++ b/tests/forcefield/test_orb_nvalchemi.py
@@ -1,0 +1,396 @@
+"""Tests for OrbWrapper (nvalchemi BaseModelMixin integration)."""
+
+import pytest
+import torch
+
+nvalchemi = pytest.importorskip("nvalchemi", reason="nvalchemi-toolkit not installed")
+
+from nvalchemi.data import AtomicData, Batch  # noqa: E402
+from nvalchemi.models.base import NeighborListFormat  # noqa: E402
+
+from orb_models.forcefield.forcefield_adapter import ForcefieldAtomsAdapter  # noqa: E402
+from orb_models.forcefield.inference.orb_nvalchemi import OrbWrapper  # noqa: E402
+from orb_models.forcefield.pretrained import (  # noqa: E402
+    orb_v3_conservative_architecture,
+    orb_v3_direct_architecture,
+)
+
+_CUTOFF = 6.0
+_MAX_NUM_NEIGHBORS = 120
+_LATENT_DIM = 32
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_water(device: str = "cpu") -> AtomicData:
+    """Single H2O molecule with a pre-computed full edge list (no PBC)."""
+    positions = torch.tensor(
+        [[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [0.0, 0.96, 0.0]],
+        dtype=torch.float32,
+        device=device,
+    )
+    numbers = torch.tensor([8, 1, 1], dtype=torch.long, device=device)
+    neighbor_list = torch.tensor(
+        [[0, 1], [1, 0], [0, 2], [2, 0], [1, 2], [2, 1]],
+        dtype=torch.long,
+        device=device,
+    )
+    return AtomicData(
+        positions=positions,
+        atomic_numbers=numbers,
+        neighbor_list=neighbor_list,
+        charge=torch.tensor([[0.0]]),
+        spin=torch.tensor([[1.0]]),
+    )
+
+
+def _make_pbc_water(device: str = "cpu") -> AtomicData:
+    """H2O in a periodic cubic box with integer neighbor_list_shifts on edges."""
+    positions = torch.tensor(
+        [[0.0, 0.0, 0.0], [0.96, 0.0, 0.0], [0.0, 0.96, 0.0]],
+        dtype=torch.float32,
+        device=device,
+    )
+    numbers = torch.tensor([8, 1, 1], dtype=torch.long, device=device)
+    neighbor_list = torch.tensor(
+        [[0, 1], [1, 0], [0, 2], [2, 0], [1, 2], [2, 1]],
+        dtype=torch.long,
+        device=device,
+    )
+    cell = (torch.eye(3, dtype=torch.float32, device=device) * 10.0).unsqueeze(0)
+    neighbor_list_shifts = torch.zeros(6, 3, dtype=torch.float32, device=device)
+    pbc = torch.tensor([[True, True, True]], device=device)
+    return AtomicData(
+        positions=positions,
+        atomic_numbers=numbers,
+        neighbor_list=neighbor_list,
+        cell=cell,
+        neighbor_list_shifts=neighbor_list_shifts,
+        pbc=pbc,
+        charge=torch.tensor([[0.0]]),
+        spin=torch.tensor([[1.0]]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def adapter():
+    return ForcefieldAtomsAdapter(radius=_CUTOFF, max_num_neighbors=_MAX_NUM_NEIGHBORS)
+
+
+@pytest.fixture
+def direct_wrapper(adapter):
+    model = orb_v3_direct_architecture(latent_dim=_LATENT_DIM)
+    return OrbWrapper(model, adapter)
+
+
+@pytest.fixture
+def conservative_wrapper(adapter):
+    model = orb_v3_conservative_architecture(latent_dim=_LATENT_DIM)
+    return OrbWrapper(model, adapter)
+
+
+@pytest.fixture
+def single_batch() -> Batch:
+    return Batch.from_data_list([_make_water()])
+
+
+@pytest.fixture
+def multi_batch() -> Batch:
+    return Batch.from_data_list([_make_water(), _make_water()])
+
+
+@pytest.fixture
+def pbc_batch() -> Batch:
+    return Batch.from_data_list([_make_pbc_water()])
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+class TestInstantiation:
+    def test_wraps_model(self, adapter):
+        model = orb_v3_conservative_architecture(latent_dim=_LATENT_DIM)
+        w = OrbWrapper(model, adapter)
+        assert w.model is model
+
+    def test_conservative_model_config(self, conservative_wrapper):
+        cfg = conservative_wrapper.model_config
+        assert "energy" in cfg.outputs
+        assert "forces" in cfg.outputs
+        assert "stress" in cfg.outputs
+
+    def test_direct_model_config(self, direct_wrapper):
+        cfg = direct_wrapper.model_config
+        assert "energy" in cfg.outputs
+        assert "forces" in cfg.outputs
+        assert "stress" in cfg.outputs
+
+
+class TestModelConfigCapabilities:
+    def test_conservative_autograd(self, conservative_wrapper):
+        cfg = conservative_wrapper.model_config
+        assert cfg.autograd_outputs == frozenset({"forces", "stress"})
+        assert "positions" in cfg.autograd_inputs
+
+    def test_direct_no_autograd(self, direct_wrapper):
+        assert not direct_wrapper.model_config.autograd_outputs
+
+    def test_pbc_and_neighbor_config(self, conservative_wrapper):
+        cfg = conservative_wrapper.model_config
+        assert cfg.supports_pbc is True
+        assert cfg.needs_pbc is False
+        assert cfg.neighbor_config is not None
+        assert cfg.neighbor_config.format == NeighborListFormat.COO
+        assert cfg.neighbor_config.cutoff == pytest.approx(_CUTOFF)
+
+
+class TestProperties:
+    def test_cutoff(self, conservative_wrapper):
+        assert conservative_wrapper.cutoff == pytest.approx(_CUTOFF)
+        assert isinstance(conservative_wrapper.cutoff, float)
+
+    def test_embedding_shapes(self, conservative_wrapper):
+        shapes = conservative_wrapper.embedding_shapes
+        assert shapes["node_embeddings"] == (_LATENT_DIM,)
+
+
+class TestAdaptInput:
+    def test_positions_present(self, conservative_wrapper, single_batch):
+        result = conservative_wrapper.adapt_input(single_batch)
+        assert "positions" in result.node_features
+        assert result.node_features["positions"].shape == (3, 3)
+
+    def test_atomic_numbers_present(self, conservative_wrapper, single_batch):
+        result = conservative_wrapper.adapt_input(single_batch)
+        assert "atomic_numbers" in result.node_features
+        assert result.node_features["atomic_numbers"].shape == (3,)
+
+    def test_edge_vectors_present(self, conservative_wrapper, single_batch):
+        result = conservative_wrapper.adapt_input(single_batch)
+        assert "vectors" in result.edge_features
+        E = single_batch.neighbor_list.shape[0]
+        assert result.edge_features["vectors"].shape == (E, 3)
+
+    def test_atomic_data_promoted_to_batch(self, conservative_wrapper):
+        data = _make_water()
+        result = conservative_wrapper.adapt_input(data)
+        assert result.n_node.shape[0] == 1
+        assert result.n_node[0].item() == 3
+
+    def test_no_pbc_identity_cell(self, conservative_wrapper, single_batch):
+        result = conservative_wrapper.adapt_input(single_batch)
+        B = single_batch.num_graphs
+        assert result.system_features["cell"].shape == (B, 3, 3)
+        expected = torch.eye(3).unsqueeze(0).expand(B, -1, -1)
+        assert torch.allclose(result.system_features["cell"], expected)
+
+    def test_no_pbc_zero_shifts(self, conservative_wrapper, single_batch):
+        result = conservative_wrapper.adapt_input(single_batch)
+        assert result.edge_features["unit_shifts"].abs().max().item() == pytest.approx(0.0)
+
+    def test_pbc_cell_passed_through(self, conservative_wrapper, pbc_batch):
+        result = conservative_wrapper.adapt_input(pbc_batch)
+        assert torch.allclose(result.system_features["cell"][0], torch.eye(3) * 10.0, atol=1e-5)
+
+    def test_multi_batch_n_node(self, conservative_wrapper, multi_batch):
+        result = conservative_wrapper.adapt_input(multi_batch)
+        assert result.n_node.tolist() == [3, 3]
+
+    def test_charge_and_spin_passed_through(self, conservative_wrapper):
+        data = AtomicData(
+            positions=torch.randn(3, 3),
+            atomic_numbers=torch.tensor([6, 8, 1]),
+            neighbor_list=torch.tensor([[0, 1], [1, 0]]),
+            charge=torch.tensor([[2.0]]),
+            spin=torch.tensor([[3.0]]),
+        )
+        result = conservative_wrapper.adapt_input(data)
+        assert result.system_features["total_charge"].item() == pytest.approx(2.0)
+        assert result.system_features["spin_multiplicity"].item() == pytest.approx(3.0)
+
+
+class TestAdaptOutput:
+    def test_energy_key_in_output(self, conservative_wrapper, single_batch):
+        raw = {"energy": torch.randn(1)}
+        out = conservative_wrapper.adapt_output(raw, single_batch)
+        assert "energy" in out
+
+    def test_energy_shape_1d_unsqueezed(self, conservative_wrapper, single_batch):
+        raw = {"energy": torch.randn(1)}
+        out = conservative_wrapper.adapt_output(raw, single_batch)
+        assert out["energy"].shape == (1, 1)
+
+    def test_energy_already_2d(self, conservative_wrapper, single_batch):
+        raw = {"energy": torch.randn(1, 1)}
+        out = conservative_wrapper.adapt_output(raw, single_batch)
+        assert out["energy"].shape == (1, 1)
+
+    def test_forces_passed_through(self, conservative_wrapper, single_batch):
+        raw = {"energy": torch.randn(1), "forces": torch.randn(3, 3)}
+        out = conservative_wrapper.adapt_output(raw, single_batch)
+        assert "forces" in out
+        assert out["forces"].shape == (3, 3)
+
+    def test_stress_voigt_to_3x3(self, conservative_wrapper, single_batch):
+        raw = {"energy": torch.randn(1), "stress": torch.randn(1, 6)}
+        out = conservative_wrapper.adapt_output(raw, single_batch)
+        assert "stress" in out
+        assert out["stress"].shape == (1, 3, 3)
+
+    def test_stress_voigt_symmetry(self, conservative_wrapper, single_batch):
+        voigt = torch.tensor([[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]])
+        raw = {"energy": torch.randn(1), "stress": voigt}
+        out = conservative_wrapper.adapt_output(raw, single_batch)
+        s = out["stress"][0]
+        assert torch.allclose(s, s.T)
+
+    def test_missing_optional_outputs_absent(self, conservative_wrapper, single_batch):
+        raw = {"energy": torch.randn(1)}
+        out = conservative_wrapper.adapt_output(raw, single_batch)
+        assert out.get("forces") is None
+        assert out.get("stress") is None
+
+
+class TestForwardDirect:
+    def test_energy_shape_single(self, direct_wrapper, single_batch):
+        out = direct_wrapper.forward(single_batch)
+        assert out["energy"].shape == (1, 1)
+
+    def test_energy_shape_multi(self, direct_wrapper, multi_batch):
+        out = direct_wrapper.forward(multi_batch)
+        assert out["energy"].shape == (2, 1)
+
+    def test_forces_shape(self, direct_wrapper, single_batch):
+        out = direct_wrapper.forward(single_batch)
+        assert out["forces"].shape == (3, 3)
+
+    def test_forces_shape_multi(self, direct_wrapper, multi_batch):
+        out = direct_wrapper.forward(multi_batch)
+        assert out["forces"].shape == (6, 3)
+
+    def test_stress_shape(self, direct_wrapper, single_batch):
+        out = direct_wrapper.forward(single_batch)
+        assert out["stress"].shape == (1, 3, 3)
+
+    def test_stress_shape_multi(self, direct_wrapper, multi_batch):
+        out = direct_wrapper.forward(multi_batch)
+        assert out["stress"].shape == (2, 3, 3)
+
+    def test_no_forces_when_disabled(self, direct_wrapper, single_batch):
+        direct_wrapper.model_config.active_outputs = {"energy"}
+        out = direct_wrapper.forward(single_batch)
+        assert out.get("forces") is None
+
+    def test_no_stress_when_disabled(self, direct_wrapper, single_batch):
+        direct_wrapper.model_config.active_outputs = {"energy", "forces"}
+        out = direct_wrapper.forward(single_batch)
+        assert out.get("stress") is None
+
+
+class TestForwardConservative:
+    def test_energy_shape_single(self, conservative_wrapper, single_batch):
+        out = conservative_wrapper.forward(single_batch)
+        assert out["energy"].shape == (1, 1)
+
+    def test_energy_shape_multi(self, conservative_wrapper, multi_batch):
+        out = conservative_wrapper.forward(multi_batch)
+        assert out["energy"].shape == (2, 1)
+
+    def test_forces_shape(self, conservative_wrapper, single_batch):
+        out = conservative_wrapper.forward(single_batch)
+        assert out["forces"].shape == (3, 3)
+
+    def test_forces_shape_multi(self, conservative_wrapper, multi_batch):
+        out = conservative_wrapper.forward(multi_batch)
+        assert out["forces"].shape == (6, 3)
+
+    def test_stress_shape(self, conservative_wrapper, single_batch):
+        out = conservative_wrapper.forward(single_batch)
+        assert out["stress"].shape == (1, 3, 3)
+
+    def test_no_forces_when_disabled(self, conservative_wrapper, single_batch):
+        conservative_wrapper.model_config.active_outputs = {"energy"}
+        out = conservative_wrapper.forward(single_batch)
+        assert out.get("forces") is None
+
+    def test_no_stress_when_disabled(self, conservative_wrapper, single_batch):
+        conservative_wrapper.model_config.active_outputs = {"energy", "forces"}
+        out = conservative_wrapper.forward(single_batch)
+        assert out.get("stress") is None
+
+
+class TestPipelineAutograd:
+    def test_not_pipeline_autograd_by_default(self, conservative_wrapper):
+        assert not conservative_wrapper._is_pipeline_autograd()
+
+    def test_direct_never_pipeline_autograd(self, direct_wrapper):
+        direct_wrapper.model_config.active_outputs = {"energy"}
+        assert not direct_wrapper._is_pipeline_autograd()
+
+    def test_is_pipeline_autograd_when_derivatives_stripped(self, conservative_wrapper):
+        conservative_wrapper.model_config.active_outputs = {"energy"}
+        assert conservative_wrapper._is_pipeline_autograd()
+
+    def test_pipeline_autograd_returns_energy(self, conservative_wrapper, single_batch):
+        conservative_wrapper.model_config.active_outputs = {"energy"}
+        out = conservative_wrapper.forward(single_batch)
+        assert out["energy"] is not None
+
+    def test_direct_derivative_keys_conservative(self, conservative_wrapper):
+        assert conservative_wrapper.direct_derivative_keys() == set()
+
+    def test_direct_derivative_keys_direct(self, direct_wrapper):
+        assert direct_wrapper.direct_derivative_keys() == set()
+
+
+class TestPipelineAnalyticDerivatives:
+    @pytest.fixture
+    def wrapper(self, adapter):
+        model = orb_v3_conservative_architecture(latent_dim=_LATENT_DIM, has_electrostatics=True)
+        return OrbWrapper(model, adapter)
+
+    def test_pipeline_autograd_returns_analytic_forces(self, wrapper, single_batch):
+        wrapper.model_config.active_outputs = {"energy"}
+        out = wrapper.forward(single_batch)
+        assert out["forces"].shape == (3, 3)
+
+    def test_pipeline_autograd_returns_analytic_stress(self, wrapper, single_batch):
+        wrapper.model_config.active_outputs = {"energy"}
+        out = wrapper.forward(single_batch)
+        assert out["stress"].shape == (1, 3, 3)
+
+    def test_pipeline_autograd_does_not_mutate_active_outputs(self, wrapper, single_batch):
+        wrapper.model_config.active_outputs = {"energy"}
+        wrapper.forward(single_batch)
+        assert wrapper.model_config.active_outputs == {"energy"}
+
+
+class TestComputeEmbeddings:
+    def test_node_embeddings_shape(self, conservative_wrapper, single_batch):
+        result = conservative_wrapper.compute_embeddings(single_batch)
+        assert result.node_embeddings.shape == (3, _LATENT_DIM)
+
+    def test_node_embeddings_shape_multi(self, conservative_wrapper, multi_batch):
+        result = conservative_wrapper.compute_embeddings(multi_batch)
+        assert result.node_embeddings.shape == (6, _LATENT_DIM)
+
+    def test_atomic_data_input(self, conservative_wrapper):
+        data = _make_water()
+        result = conservative_wrapper.compute_embeddings(data)
+        assert result.node_embeddings.shape == (3, _LATENT_DIM)
+
+    def test_does_not_mutate_model_config(self, conservative_wrapper, single_batch):
+        conservative_wrapper.model_config.active_outputs = {"energy", "forces", "stress"}
+        conservative_wrapper.compute_embeddings(single_batch)
+        assert "forces" in conservative_wrapper.model_config.active_outputs
+        assert "stress" in conservative_wrapper.model_config.active_outputs

--- a/tests/forcefield/test_pair_repulsion.py
+++ b/tests/forcefield/test_pair_repulsion.py
@@ -82,7 +82,10 @@ def test_pair_grads(pbc):
 
     graphs = [adapter.from_ase_atoms(atoms, output_dtype=torch.float64) for a in [atoms, atoms]]
     batch = AtomGraphs.batch(graphs)
-    vectors, displacement, generator = batch.compute_differentiable_edge_vectors()
+    geom = batch.compute_differentiable_edge_vectors()
+    vectors = geom.edge_vectors
+    displacement = geom.stress_displacement
+    generator = geom.rotation_generator
     batch.edge_features["vectors"] = vectors
     out = pair_repulsion(batch)
 


### PR DESCRIPTION
# Summary

* Adds `OrbWrapper`, a nvalchemi-toolkit integration that lets Orb models plug into nvalchemi dynamics engines (FIRE, MD, etc.) and pipeline composition (e.g. Orb + DFT-D3; conservative-models only)
* Adds README examples how to use the wrapper
