### PR TITLE
Fix D3 wrapping for periodic positions

### DIFF
--- a/orb_models/common/atoms/graph_featurization.py
+++ b/orb_models/common/atoms/graph_featurization.py
@@ -726,6 +726,7 @@ def _compute_neighbor_list_with_fallback(
     fallback_safety_factor: float = 5.0,
     atomic_density: float = 0.35,
     fill_value: int | None = None,
+    wrap_positions: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Compute neighbor list with automatic fallback if initial estimate is too low.
 
@@ -755,7 +756,7 @@ def _compute_neighbor_list_with_fallback(
             batch_ptr=batch_ptr,
             fill_value=fill_value,
             max_neighbors=max_num_neighbors_alchemi,
-            wrap_positions=False,  # we handle wrapping externally
+            wrap_positions=wrap_positions,
         )
         if max_num_neighbors_alchemi >= num_neighbors.max().item():
             return neighbor_matrix, num_neighbors, neighbor_shift_matrix

--- a/orb_models/forcefield/inference/d3_model.py
+++ b/orb_models/forcefield/inference/d3_model.py
@@ -152,6 +152,7 @@ class AlchemiDFTD3(torch.nn.Module):
                     atomic_density=self.atomic_density,
                     initial_safety_factor=self.safety_factor,
                     fallback_safety_factor=self.fallback_safety_factor,
+                    wrap_positions=True,
                 )
             )
             # Truncate the neighbor matrix to save computation/memory

--- a/tests/forcefield/test_d3.py
+++ b/tests/forcefield/test_d3.py
@@ -115,3 +115,37 @@ def test_pbe_bj_periodic_agreement(
         rtol=0.1,
         atol=1e-6,
     )
+
+
+def test_d3_forward_wraps_periodic_positions():
+    """D3 should be invariant to integer-cell translations of periodic positions."""
+    cell = torch.eye(3).unsqueeze(0) * 10.0
+    pbc = torch.tensor([[True, True, True]])
+    atomic_numbers = torch.tensor([8, 8], dtype=torch.long)
+    node_batch_index = torch.zeros(2, dtype=torch.int32)
+
+    positions = torch.tensor([[1.0, 1.0, 1.0], [2.0, 1.0, 1.0]])
+    unwrapped_positions = positions.clone()
+    unwrapped_positions[1, 0] += 2 * cell[0, 0, 0]
+
+    model = AlchemiDFTD3(functional="PBE", damping="BJ", cutoff=8.0, has_stress=False)
+    wrapped = model(
+        positions,
+        cell,
+        atomic_numbers,
+        pbc,
+        node_batch_index,
+        compute_forces=False,
+        compute_stress=False,
+    )
+    unwrapped = model(
+        unwrapped_positions,
+        cell,
+        atomic_numbers,
+        pbc,
+        node_batch_index,
+        compute_forces=False,
+        compute_stress=False,
+    )
+
+    torch.testing.assert_close(unwrapped["energy"], wrapped["energy"], rtol=1e-6, atol=1e-8)


### PR DESCRIPTION
## Summary
- pass wrap_positions through the nvalchemiops neighbor-list helper
- make AlchemiDFTD3 request wrapping internally so direct D3 calls are invariant to unwrapped periodic coordinates
- add a regression test for integer-cell translated periodic positions

## Why
AlchemiDFTD3.forward is a public wrapper boundary and can be called directly by dynamics code. It previously relied on callers to pre-wrap periodic positions, which can silently undercount D3 interactions for unwrapped coordinates.

## Tests
- /Users/timothyduignan/Projects/orb-meta/SIM/libs/core/.venv/bin/python -m pytest tests/forcefield/test_d3.py -q
- /Users/timothyduignan/Projects/orb-meta/SIM/libs/core/.venv/bin/python -m ruff check orb_models/common/atoms/graph_featurization.py orb_models/forcefield/inference/d3_model.py tests/forcefield/test_d3.py
- git diff --check