### PR TITLE
Expose OrbMol-v2 per-atom charges and dipole via ASE

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -27,7 +27,7 @@ model, atoms_adapter = orbmol_v2(device="cuda")
 # atoms.info["charge"] and atoms.info["spin"] (multiplicity, = 2S+1) must be set.
 ```
 
-> **Caution:** While the model does predict per-atom charge values as a latent feature in the charge head, the model has not seen any per-atom charge values during training; these are emergent from optimisation against energies and forces alone. They should therefore be treated with caution: while in at least some cases they appear to correspond to the correct physical values, the reliability and generality of this correspondence is unclear and is the subject of ongoing investigations. For trial purposes they are returned as `charges` from `predict()`, and — for those who opt in by passing `use_experimental_charges=True` to `ORBCalculator` — as ASE's `charges` and `dipole` properties.
+> **Caution:** While the model does predict per-atom charge values as a latent feature in the charge head, the model has not seen any per-atom charge values during training; these are emergent from optimisation against energies and forces alone. They should therefore be treated with caution: while in at least some cases they appear to correspond to the correct physical values, the reliability and generality of this correspondence is unclear and is the subject of ongoing investigations. For trial purposes they can be opted into with `orbmol_v2(expose_experimental_charges=True)` (or `model.enable_charges()`), which returns them as `charges` from `predict()` and exposes them as ASE's `charges` and `dipole` properties via `ORBCalculator`.
 
 ### [V3 Models](https://arxiv.org/abs/2504.06231)
 

--- a/MODELS.md
+++ b/MODELS.md
@@ -27,7 +27,7 @@ model, atoms_adapter = orbmol_v2(device="cuda")
 # atoms.info["charge"] and atoms.info["spin"] (multiplicity, = 2S+1) must be set.
 ```
 
-> **Caution:** While the model does predict per-atom charge values as a latent feature in the charge head, the model has not seen any per-atom charge values during training; these are emergent from optimisation against energies and forces alone. They should therefore be treated with caution: while in at least some cases they appear to correspond to the correct physical values, the reliability and generality of this correspondence is unclear and is the subject of ongoing investigations. For trial purposes they can be opted into with `orbmol_v2(expose_experimental_charges=True)` (or `model.enable_charges()`), which returns them as `charges` from `predict()` and exposes them as ASE's `charges` and `dipole` properties via `ORBCalculator`.
+> **Caution:** While the model does predict per-atom charge values as a latent feature in the charge head, the model has not seen any per-atom charge values during training; these are emergent from optimisation against energies and forces alone. They should therefore be treated with caution: while in at least some cases they appear to correspond to the correct physical values, the reliability and generality of this correspondence is unclear and is the subject of ongoing investigations. For experimental purposes they can be opted into with `orbmol_v2(expose_experimental_charges=True)` (or `model.enable_charges()`), which returns them as `charges` from `predict()` and from all wrappers (ASE, TorchSim, nvalchemi); the ASE calculator also derives `dipole`.
 
 ### [V3 Models](https://arxiv.org/abs/2504.06231)
 

--- a/MODELS.md
+++ b/MODELS.md
@@ -27,7 +27,7 @@ model, atoms_adapter = orbmol_v2(device="cuda")
 # atoms.info["charge"] and atoms.info["spin"] (multiplicity, = 2S+1) must be set.
 ```
 
-> **Caution:** While the model does predict per-atom charge values as a latent feature in the charge head, the model has not seen any per-atom charge values during training; these are emergent from optimisation against energies and forces alone. They should therefore be treated with caution: while in at least some cases they appear to correspond to the correct physical values, the reliability and generality of this correspondence is unclear and is the subject of ongoing investigations. For trial purposes they are returned as `charges` from `predict()`, and as ASE's `charges` and `dipole` properties from `ORBCalculator`.
+> **Caution:** While the model does predict per-atom charge values as a latent feature in the charge head, the model has not seen any per-atom charge values during training; these are emergent from optimisation against energies and forces alone. They should therefore be treated with caution: while in at least some cases they appear to correspond to the correct physical values, the reliability and generality of this correspondence is unclear and is the subject of ongoing investigations. For trial purposes they are returned as `charges` from `predict()`, and — for those who opt in by passing `use_experimental_charges=True` to `ORBCalculator` — as ASE's `charges` and `dipole` properties.
 
 ### [V3 Models](https://arxiv.org/abs/2504.06231)
 

--- a/MODELS.md
+++ b/MODELS.md
@@ -27,7 +27,7 @@ model, atoms_adapter = orbmol_v2(device="cuda")
 # atoms.info["charge"] and atoms.info["spin"] (multiplicity, = 2S+1) must be set.
 ```
 
-> **Caution:** While the model does predict per-atom charge values as a latent feature in the charge head, the model has not seen any per-atom charge values during training; these are emergent from optimisation against energies and forces alone. They should therefore be treated with caution: while in at least some cases they appear to correspond to the correct physical values, the reliability and generality of this correspondence is unclear and is the subject of ongoing investigations.
+> **Caution:** While the model does predict per-atom charge values as a latent feature in the charge head, the model has not seen any per-atom charge values during training; these are emergent from optimisation against energies and forces alone. They should therefore be treated with caution: while in at least some cases they appear to correspond to the correct physical values, the reliability and generality of this correspondence is unclear and is the subject of ongoing investigations. For trial purposes they are returned as `charges` from `predict()`, and as ASE's `charges` and `dipole` properties from `ORBCalculator`.
 
 ### [V3 Models](https://arxiv.org/abs/2504.06231)
 

--- a/orb_models/forcefield/inference/calculator.py
+++ b/orb_models/forcefield/inference/calculator.py
@@ -21,6 +21,7 @@ class ORBCalculator(Calculator):
         edge_method: EdgeCreationMethod | None = None,
         max_num_neighbors: int | None = None,
         half_supercell: bool | None = None,
+        use_experimental_charges: bool = False,
         device: torch.device | str | None = None,
         directory: str = ".",
     ):
@@ -40,6 +41,15 @@ class ORBCalculator(Calculator):
                 This flag does not affect the resulting graph; it is purely an optimization that can double
                 throughput and half memory for very large cells (e.g. 5k+ atoms). For smaller systems, it can hurt
                 performance due to additional computation to enforce max_num_neighbors.
+            use_experimental_charges (bool): Whether to expose the model's per-atom charges
+                as ASE's `charges` property, and a point-charge `dipole` derived from them.
+                Defaults to False, and has no effect on models without a latent charge head.
+                The model has not seen any per-atom charge values during training; these are
+                emergent from optimisation against energies and forces alone. They should
+                therefore be treated with caution: while in at least some cases they appear to
+                correspond to the correct physical values, the reliability and generality of
+                this correspondence is unclear and is the subject of ongoing investigations.
+                See MODELS.md for details.
             device (torch.device, optional): The device to use for the model.
             directory (str, optional): Working directory in which to read and write files and perform calculations.
         """
@@ -62,9 +72,13 @@ class ORBCalculator(Calculator):
             conditioner, ChargeSpinConditioner
         )
 
+        self.use_experimental_charges = use_experimental_charges
         properties = list(model.properties)  # type: ignore
         if "charges" in properties:
-            properties.append("dipole")
+            if use_experimental_charges:
+                properties.append("dipole")
+            else:
+                properties.remove("charges")
         self.implemented_properties = properties
 
     def check_state(self, atoms, tol=1e-15):

--- a/orb_models/forcefield/inference/calculator.py
+++ b/orb_models/forcefield/inference/calculator.py
@@ -21,7 +21,6 @@ class ORBCalculator(Calculator):
         edge_method: EdgeCreationMethod | None = None,
         max_num_neighbors: int | None = None,
         half_supercell: bool | None = None,
-        use_experimental_charges: bool = False,
         device: torch.device | str | None = None,
         directory: str = ".",
     ):
@@ -41,15 +40,6 @@ class ORBCalculator(Calculator):
                 This flag does not affect the resulting graph; it is purely an optimization that can double
                 throughput and half memory for very large cells (e.g. 5k+ atoms). For smaller systems, it can hurt
                 performance due to additional computation to enforce max_num_neighbors.
-            use_experimental_charges (bool): Whether to expose the model's per-atom charges
-                as ASE's `charges` property, and a point-charge `dipole` derived from them.
-                Defaults to False, and has no effect on models without a latent charge head.
-                The model has not seen any per-atom charge values during training; these are
-                emergent from optimisation against energies and forces alone. They should
-                therefore be treated with caution: while in at least some cases they appear to
-                correspond to the correct physical values, the reliability and generality of
-                this correspondence is unclear and is the subject of ongoing investigations.
-                See MODELS.md for details.
             device (torch.device, optional): The device to use for the model.
             directory (str, optional): Working directory in which to read and write files and perform calculations.
         """
@@ -72,13 +62,10 @@ class ORBCalculator(Calculator):
             conditioner, ChargeSpinConditioner
         )
 
-        self.use_experimental_charges = use_experimental_charges
+        # "charges" is present only when the model opts in via enable_charges().
         properties = list(model.properties)  # type: ignore
         if "charges" in properties:
-            if use_experimental_charges:
-                properties.append("dipole")
-            else:
-                properties.remove("charges")
+            properties.append("dipole")
         self.implemented_properties = properties
 
     def check_state(self, atoms, tol=1e-15):

--- a/orb_models/forcefield/inference/calculator.py
+++ b/orb_models/forcefield/inference/calculator.py
@@ -62,7 +62,6 @@ class ORBCalculator(Calculator):
             conditioner, ChargeSpinConditioner
         )
 
-        # "charges" is present only when the model opts in via enable_charges().
         properties = list(model.properties)  # type: ignore
         if "charges" in properties:
             properties.append("dipole")

--- a/orb_models/forcefield/inference/calculator.py
+++ b/orb_models/forcefield/inference/calculator.py
@@ -62,7 +62,10 @@ class ORBCalculator(Calculator):
             conditioner, ChargeSpinConditioner
         )
 
-        self.implemented_properties = model.properties  # type: ignore
+        properties = list(model.properties)  # type: ignore
+        if "charges" in properties:
+            properties.append("dipole")
+        self.implemented_properties = properties
 
     def check_state(self, atoms, tol=1e-15):
         """Check if calculation is needed.
@@ -122,7 +125,17 @@ class ORBCalculator(Calculator):
             # ASE expects:
             #  - stresses to be squeezed to a 1D array of shape (6,)
             #  - forces to never be squeezed i.e. single-atom systems should be (1, 3)
+            #  - charges to be (n_atoms,)
             if prop == "stress":
                 self.results[prop] = to_numpy(out[out_key].squeeze())
+            elif prop == "charges":
+                self.results[prop] = out[out_key].detach().reshape(-1).cpu().numpy()
             else:
                 self.results[prop] = to_numpy(out[out_key])
+
+        if "dipole" in self.implemented_properties and "charges" in self.results:
+            atoms = self.atoms
+            # Point-charge dipole sum_i q_i r_i, in e*A (ASE's convention). Only
+            # defined for non-periodic systems, and origin-dependent unless neutral.
+            if atoms is not None and not atoms.pbc.any():
+                self.results["dipole"] = self.results["charges"] @ atoms.get_positions()

--- a/orb_models/forcefield/inference/orb_nvalchemi.py
+++ b/orb_models/forcefield/inference/orb_nvalchemi.py
@@ -287,9 +287,6 @@ class OrbWrapper(nn.Module, BaseModelMixin):
         if stress is not None:
             output["stress"] = _voigt_6_to_full_3x3(torch.atleast_2d(stress))
 
-        # Charges must be emitted whenever declared: nvalchemi treats "charges" as a
-        # producer output that Ewald/PME consume as a required input, so a pipeline
-        # wires this model to them on the strength of the declaration alone.
         charges = raw_output.get("charges")
         if charges is not None and "charges" in self.model_config.active_outputs:
             output["charges"] = charges

--- a/orb_models/forcefield/inference/orb_nvalchemi.py
+++ b/orb_models/forcefield/inference/orb_nvalchemi.py
@@ -287,6 +287,13 @@ class OrbWrapper(nn.Module, BaseModelMixin):
         if stress is not None:
             output["stress"] = _voigt_6_to_full_3x3(torch.atleast_2d(stress))
 
+        # Charges must be emitted whenever declared: nvalchemi treats "charges" as a
+        # producer output that Ewald/PME consume as a required input, so a pipeline
+        # wires this model to them on the strength of the declaration alone.
+        charges = raw_output.get("charges")
+        if charges is not None and "charges" in self.model_config.active_outputs:
+            output["charges"] = charges
+
         return output
 
     # ------------------------------------------------------------------

--- a/orb_models/forcefield/models/conservative_regressor.py
+++ b/orb_models/forcefield/models/conservative_regressor.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Mapping
 from typing import Any, Literal, cast
 
@@ -54,6 +55,7 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
         pair_repulsion: bool = False,
         has_stress: bool = True,
         coulomb_module: CoulombModule | None = None,
+        expose_experimental_charges: bool = False,
         **kwargs,
     ):
         super().__init__()
@@ -109,6 +111,36 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
             if heads[name] is not None:
                 self.extra_properties.append(heads[name].target.fullname)
 
+        self.expose_charges = False
+        if expose_experimental_charges:
+            self.enable_charges()
+
+    def enable_charges(self) -> None:
+        """Expose the latent per-atom charges as a "charges" prediction.
+
+        Emits a warning, because these values are experimental: the model has not
+        seen any per-atom charge values during training; they are emergent from
+        optimisation against energies and forces alone. See MODELS.md.
+        """
+        if "latent_charges" not in self.heads:
+            raise ValueError("Cannot expose charges: this model has no 'latent_charges' head.")
+        warnings.warn(
+            "Exposing experimental per-atom charges. The model has not seen any "
+            "per-atom charge values during training; these are emergent from "
+            "optimisation against energies and forces alone. They should therefore "
+            "be treated with caution: while in at least some cases they appear to "
+            "correspond to the correct physical values, the reliability and "
+            "generality of this correspondence is unclear and is the subject of "
+            "ongoing investigations. See MODELS.md for details.",
+            UserWarning,
+            stacklevel=2,
+        )
+        self.expose_charges = True
+
+    def disable_charges(self) -> None:
+        """Stop exposing the latent per-atom charges."""
+        self.expose_charges = False
+
     def enable_stress(self) -> None:
         """Enable stress computation. No-op if already enabled."""
         self.has_stress = True
@@ -128,7 +160,7 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
         if self.has_stress:
             props.append("stress")
         props.extend(self.extra_properties)
-        if "latent_charges" in self.heads:
+        if self.expose_charges:
             props.append("charges")
         return props
 
@@ -267,8 +299,8 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
             "energy"  — absolute energy (B,)
             "forces"  — total forces (N, 3)
             "stress"  — total stress in Voigt notation (B, 6)
-            "charges" — per-atom charges (N,) in e, if a latent_charges head exists;
-                        emergent from energy/force fitting alone, see MODELS.md
+            "charges" — per-atom charges (N,) in e, only when enable_charges() has been
+                        called; emergent from energy/force fitting alone, see MODELS.md
         """
         # self() not self.forward() to respect torch.compile
         preds = self(
@@ -293,7 +325,7 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
             else:
                 raise ValueError(f"Expected ForcefieldHead or ConfidenceHead, got {type(head)}.")
 
-        if "charges" in preds:
+        if self.expose_charges:
             out["charges"] = preds["charges"]
 
         if split:

--- a/orb_models/forcefield/models/conservative_regressor.py
+++ b/orb_models/forcefield/models/conservative_regressor.py
@@ -116,12 +116,7 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
             self.enable_charges()
 
     def enable_charges(self) -> None:
-        """Expose the latent per-atom charges as a "charges" prediction.
-
-        Emits a warning, because these values are experimental: the model has not
-        seen any per-atom charge values during training; they are emergent from
-        optimisation against energies and forces alone. See MODELS.md.
-        """
+        """Expose the latent per-atom charges as a "charges" prediction."""
         if "latent_charges" not in self.heads:
             raise ValueError("Cannot expose charges: this model has no 'latent_charges' head.")
         warnings.warn(

--- a/orb_models/forcefield/models/conservative_regressor.py
+++ b/orb_models/forcefield/models/conservative_regressor.py
@@ -99,7 +99,7 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
 
         self.has_stress = has_stress
 
-        collisions = {"forces", "stress"} & heads.keys()
+        collisions = {"forces", "stress", "charges"} & heads.keys()
         assert not collisions, (
             f"Heads {collisions} collide with gradient-based prediction keys in predict()."
         )
@@ -128,6 +128,8 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
         if self.has_stress:
             props.append("stress")
         props.extend(self.extra_properties)
+        if "latent_charges" in self.heads:
+            props.append("charges")
         return props
 
     @property
@@ -158,6 +160,7 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
                 "energy"              — absolute energy (B,); fp64 when fp64_energy=True
                 "forces"              — total forces (N, 3), autograd + explicit
                 "stress"              — total stress (B, 6) in Voigt notation
+                "charges"             — per-atom charges (N,) in e, if a latent_charges head exists
 
             Components (used by loss and pipeline frameworks):
                 "interaction_energy"  — energy without reference (B,)
@@ -182,6 +185,8 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
         latent_charges = None
         if "latent_charges" in self.heads:
             latent_charges = self.heads["latent_charges"](node_features, batch)
+            # (N,) for consumers; the (N, 1) form feeds the energy head / CoulombModule.
+            out["charges"] = latent_charges.squeeze(-1)
 
         latent_spins = None
         if "latent_spins" in self.heads:
@@ -262,6 +267,8 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
             "energy"  — absolute energy (B,)
             "forces"  — total forces (N, 3)
             "stress"  — total stress in Voigt notation (B, 6)
+            "charges" — per-atom charges (N,) in e, if a latent_charges head exists;
+                        emergent from energy/force fitting alone, see MODELS.md
         """
         # self() not self.forward() to respect torch.compile
         preds = self(
@@ -285,6 +292,9 @@ class ConservativeForcefieldRegressor(base.RegressorModelMixin[AtomGraphs]):
                 out[name] = torch.softmax(preds[name], dim=-1)
             else:
                 raise ValueError(f"Expected ForcefieldHead or ConfidenceHead, got {type(head)}.")
+
+        if "charges" in preds:
+            out["charges"] = preds["charges"]
 
         if split:
             for name, pred in out.items():

--- a/orb_models/forcefield/pretrained.py
+++ b/orb_models/forcefield/pretrained.py
@@ -216,6 +216,7 @@ def orb_v3_conservative_architecture(
     has_stress: bool = True,
     has_electrostatics: bool = False,
     use_per_atom_spins: bool = False,
+    expose_experimental_charges: bool = False,
     device: torch.device | str | None = None,
 ) -> ConservativeForcefieldRegressor:
     """The orb-v3 conservative architecture.
@@ -307,6 +308,7 @@ def orb_v3_conservative_architecture(
         pair_repulsion=True,
         has_stress=has_stress,
         coulomb_module=CoulombModule() if has_electrostatics else None,
+        expose_experimental_charges=expose_experimental_charges,
     )
     device = get_device(device)
     if device is not None and device != torch.device("cpu"):
@@ -414,10 +416,16 @@ def orbmol_v2(
     train: bool = False,
     train_reference_energies: bool = False,
     loss_weights: dict[str, float] | None = None,
+    expose_experimental_charges: bool = False,
 ) -> tuple[ConservativeForcefieldRegressor, ForcefieldAtomsAdapter]:
     """Load OrbMol-v2 with learnable electrostatics (charges, Coulomb).
 
     Trained on OMol25 and OPoly26 (ωB97M-V/def2-TZVPD).
+
+    Set expose_experimental_charges=True to additionally return the model's
+    per-atom charges as "charges" from predict() — and hence via ORBCalculator,
+    OrbTorchSimModel and OrbWrapper. These charges are experimental; see
+    ConservativeForcefieldRegressor.enable_charges() and MODELS.md.
     """
     if compile is None and train:
         compile = False
@@ -442,6 +450,7 @@ def orbmol_v2(
         has_charge_spin_cond=True,
         has_stress=False,
         has_electrostatics=True,
+        expose_experimental_charges=expose_experimental_charges,
         device=device,
     )
     model = load_model(

--- a/orb_models/forcefield/pretrained.py
+++ b/orb_models/forcefield/pretrained.py
@@ -422,10 +422,9 @@ def orbmol_v2(
 
     Trained on OMol25 and OPoly26 (ωB97M-V/def2-TZVPD).
 
-    Set expose_experimental_charges=True to additionally return the model's
-    per-atom charges as "charges" from predict() — and hence via ORBCalculator,
-    OrbTorchSimModel and OrbWrapper. These charges are experimental; see
-    ConservativeForcefieldRegressor.enable_charges() and MODELS.md.
+    Set expose_experimental_charges=True to return the model's per-atom charges
+    as "charges" from predict() — and hence via ORBCalculator, OrbTorchSimModel
+    and OrbWrapper. These charges are experimental; see MODELS.md.
     """
     if compile is None and train:
         compile = False

--- a/tests/forcefield/conftest.py
+++ b/tests/forcefield/conftest.py
@@ -232,6 +232,14 @@ def conservative_regressor(gns_model, energy_head, latent_charge_head, coulomb_m
 
 
 @pytest.fixture
+def charge_regressor(conservative_regressor):
+    """A conservative regressor that has opted in to exposing latent charges."""
+    with pytest.warns(UserWarning, match="experimental per-atom charges"):
+        conservative_regressor.enable_charges()
+    return conservative_regressor
+
+
+@pytest.fixture
 def direct_regressor(gns_model, energy_head, force_head, stress_head):
     return DirectForcefieldRegressor(
         heads={"energy": energy_head, "forces": force_head, "stress": stress_head},

--- a/tests/forcefield/test_calculator.py
+++ b/tests/forcefield/test_calculator.py
@@ -1,3 +1,8 @@
+import numpy as np
+import pytest
+from ase import Atoms
+from ase.build import molecule
+
 from orb_models.forcefield.forcefield_adapter import ForcefieldAtomsAdapter
 from orb_models.forcefield.inference.calculator import ORBCalculator
 
@@ -77,3 +82,50 @@ def test_direct_stress_enabled(direct_regressor, mptraj_10_systems_db):
     calc.calculate(atoms)
     assert "stress" in calc.results
     assert "forces" in calc.results
+
+
+@pytest.mark.parametrize(
+    ("atoms", "total_charge"),
+    [
+        (molecule("H2O"), 1),
+        # Single atom: guards against to_numpy collapsing (1,) to a Python float.
+        (Atoms("H", positions=[[0.0, 0.0, 0.0]]), 0),
+    ],
+)
+def test_charges(conservative_regressor, atoms, total_charge):
+    """Charges are exposed to ASE as (n_atoms,) and sum to the requested total."""
+    atoms.info["charge"] = total_charge
+    atoms.info["spin"] = 1
+    calc = ORBCalculator(
+        model=conservative_regressor,
+        atoms_adapter=ForcefieldAtomsAdapter(6.0, 20),
+    )
+    assert "charges" in calc.implemented_properties
+    atoms.calc = calc
+
+    charges = atoms.get_charges()
+    assert charges.shape == (len(atoms),)
+    assert np.isfinite(charges).all()
+    assert charges.sum() == pytest.approx(total_charge, abs=1e-5)
+
+
+def test_dipole(conservative_regressor, mptraj_10_systems_db):
+    """Dipole is the point-charge sum, and only available for non-periodic systems."""
+    adapter = ForcefieldAtomsAdapter(6.0, 20)
+
+    atoms = molecule("H2O")
+    atoms.info["charge"] = 0
+    atoms.info["spin"] = 1
+    atoms.calc = ORBCalculator(model=conservative_regressor, atoms_adapter=adapter)
+
+    dipole = atoms.get_dipole_moment()
+    assert dipole.shape == (3,)
+    np.testing.assert_allclose(dipole, atoms.get_charges() @ atoms.get_positions(), rtol=1e-6)
+
+    periodic = mptraj_10_systems_db.get_atoms(1)
+    periodic.info["charge"] = 0
+    periodic.info["spin"] = 1
+    calc = ORBCalculator(model=conservative_regressor, atoms_adapter=adapter)
+    calc.calculate(periodic)
+    assert "charges" in calc.results
+    assert "dipole" not in calc.results

--- a/tests/forcefield/test_calculator.py
+++ b/tests/forcefield/test_calculator.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from ase import Atoms
 from ase.build import molecule
+from ase.calculators.calculator import PropertyNotImplementedError
 
 from orb_models.forcefield.forcefield_adapter import ForcefieldAtomsAdapter
 from orb_models.forcefield.inference.calculator import ORBCalculator
@@ -99,6 +100,7 @@ def test_charges(conservative_regressor, atoms, total_charge):
     calc = ORBCalculator(
         model=conservative_regressor,
         atoms_adapter=ForcefieldAtomsAdapter(6.0, 20),
+        use_experimental_charges=True,
     )
     assert "charges" in calc.implemented_properties
     atoms.calc = calc
@@ -116,7 +118,9 @@ def test_dipole(conservative_regressor, mptraj_10_systems_db):
     atoms = molecule("H2O")
     atoms.info["charge"] = 0
     atoms.info["spin"] = 1
-    atoms.calc = ORBCalculator(model=conservative_regressor, atoms_adapter=adapter)
+    atoms.calc = ORBCalculator(
+        model=conservative_regressor, atoms_adapter=adapter, use_experimental_charges=True
+    )
 
     dipole = atoms.get_dipole_moment()
     assert dipole.shape == (3,)
@@ -125,7 +129,29 @@ def test_dipole(conservative_regressor, mptraj_10_systems_db):
     periodic = mptraj_10_systems_db.get_atoms(1)
     periodic.info["charge"] = 0
     periodic.info["spin"] = 1
-    calc = ORBCalculator(model=conservative_regressor, atoms_adapter=adapter)
+    calc = ORBCalculator(
+        model=conservative_regressor, atoms_adapter=adapter, use_experimental_charges=True
+    )
     calc.calculate(periodic)
     assert "charges" in calc.results
     assert "dipole" not in calc.results
+
+
+def test_charges_require_opt_in(conservative_regressor):
+    """Charges and dipole are absent unless use_experimental_charges is set."""
+    atoms = molecule("H2O")
+    atoms.info["charge"] = 0
+    atoms.info["spin"] = 1
+    calc = ORBCalculator(
+        model=conservative_regressor, atoms_adapter=ForcefieldAtomsAdapter(6.0, 20)
+    )
+    assert "charges" not in calc.implemented_properties
+    assert "dipole" not in calc.implemented_properties
+
+    calc.calculate(atoms)
+    assert "charges" not in calc.results
+    assert "dipole" not in calc.results
+
+    atoms.calc = calc
+    with pytest.raises(PropertyNotImplementedError):
+        atoms.get_charges()

--- a/tests/forcefield/test_calculator.py
+++ b/tests/forcefield/test_calculator.py
@@ -93,14 +93,13 @@ def test_direct_stress_enabled(direct_regressor, mptraj_10_systems_db):
         (Atoms("H", positions=[[0.0, 0.0, 0.0]]), 0),
     ],
 )
-def test_charges(conservative_regressor, atoms, total_charge):
+def test_charges(charge_regressor, atoms, total_charge):
     """Charges are exposed to ASE as (n_atoms,) and sum to the requested total."""
     atoms.info["charge"] = total_charge
     atoms.info["spin"] = 1
     calc = ORBCalculator(
-        model=conservative_regressor,
+        model=charge_regressor,
         atoms_adapter=ForcefieldAtomsAdapter(6.0, 20),
-        use_experimental_charges=True,
     )
     assert "charges" in calc.implemented_properties
     atoms.calc = calc
@@ -111,16 +110,14 @@ def test_charges(conservative_regressor, atoms, total_charge):
     assert charges.sum() == pytest.approx(total_charge, abs=1e-5)
 
 
-def test_dipole(conservative_regressor, mptraj_10_systems_db):
+def test_dipole(charge_regressor, mptraj_10_systems_db):
     """Dipole is the point-charge sum, and only available for non-periodic systems."""
     adapter = ForcefieldAtomsAdapter(6.0, 20)
 
     atoms = molecule("H2O")
     atoms.info["charge"] = 0
     atoms.info["spin"] = 1
-    atoms.calc = ORBCalculator(
-        model=conservative_regressor, atoms_adapter=adapter, use_experimental_charges=True
-    )
+    atoms.calc = ORBCalculator(model=charge_regressor, atoms_adapter=adapter)
 
     dipole = atoms.get_dipole_moment()
     assert dipole.shape == (3,)
@@ -129,16 +126,14 @@ def test_dipole(conservative_regressor, mptraj_10_systems_db):
     periodic = mptraj_10_systems_db.get_atoms(1)
     periodic.info["charge"] = 0
     periodic.info["spin"] = 1
-    calc = ORBCalculator(
-        model=conservative_regressor, atoms_adapter=adapter, use_experimental_charges=True
-    )
+    calc = ORBCalculator(model=charge_regressor, atoms_adapter=adapter)
     calc.calculate(periodic)
     assert "charges" in calc.results
     assert "dipole" not in calc.results
 
 
 def test_charges_require_opt_in(conservative_regressor):
-    """Charges and dipole are absent unless use_experimental_charges is set."""
+    """Charges and dipole are absent until the model opts in via enable_charges()."""
     atoms = molecule("H2O")
     atoms.info["charge"] = 0
     atoms.info["spin"] = 1

--- a/tests/forcefield/test_conservative.py
+++ b/tests/forcefield/test_conservative.py
@@ -19,15 +19,33 @@ def test_regressor_forward(request, conservative_regressor, graph_name):
     assert "stress" in out
 
 
-def test_predict_charges(conservative_regressor, batch):
+def test_predict_charges(charge_regressor, batch):
     """Per-atom charges are exposed as (N,) and sum to the system total charge."""
-    assert "charges" in conservative_regressor.properties
-    charges = conservative_regressor.predict(batch)["charges"]
+    assert "charges" in charge_regressor.properties
+    charges = charge_regressor.predict(batch)["charges"]
     assert charges.shape == (batch.n_node.sum(),)
 
     # The batch fixture carries no total_charge, so charges are centered on zero.
     per_system = aggregate_nodes(charges, batch.n_node, reduction="sum")
     torch.testing.assert_close(per_system, torch.zeros_like(per_system), atol=1e-6, rtol=0)
+
+
+def test_charges_not_exposed_by_default(conservative_regressor, batch):
+    """Charges stay out of properties/predict() until enable_charges() is called."""
+    assert "charges" not in conservative_regressor.properties
+    assert "charges" not in conservative_regressor.predict(batch)
+
+
+def test_enable_charges_requires_head(gns_model, energy_head):
+    """enable_charges() is an error on a model with no latent_charges head."""
+    regressor = ConservativeForcefieldRegressor(
+        heads={"energy": energy_head},
+        model=gns_model,
+        loss_weights={"energy": 1.0, "forces": 1.0, "stress": 1.0, "rotational_grad": 1.0},
+    )
+    assert "charges" not in regressor.properties
+    with pytest.raises(ValueError, match="no 'latent_charges' head"):
+        regressor.enable_charges()
 
 
 def test_regressor_loss(conservative_regressor, batch):

--- a/tests/forcefield/test_conservative.py
+++ b/tests/forcefield/test_conservative.py
@@ -5,6 +5,7 @@ import torch
 from ase import Atom, Atoms
 
 from orb_models.common.atoms.batch.graph_batch import AtomGraphs
+from orb_models.common.models.segment_ops import aggregate_nodes
 from orb_models.forcefield.forcefield_adapter import ForcefieldAtomsAdapter
 from orb_models.forcefield.models.conservative_regressor import ConservativeForcefieldRegressor
 
@@ -16,6 +17,17 @@ def test_regressor_forward(request, conservative_regressor, graph_name):
     assert "energy" in out
     assert "forces" in out
     assert "stress" in out
+
+
+def test_predict_charges(conservative_regressor, batch):
+    """Per-atom charges are exposed as (N,) and sum to the system total charge."""
+    assert "charges" in conservative_regressor.properties
+    charges = conservative_regressor.predict(batch)["charges"]
+    assert charges.shape == (batch.n_node.sum(),)
+
+    # The batch fixture carries no total_charge, so charges are centered on zero.
+    per_system = aggregate_nodes(charges, batch.n_node, reduction="sum")
+    torch.testing.assert_close(per_system, torch.zeros_like(per_system), atol=1e-6, rtol=0)
 
 
 def test_regressor_loss(conservative_regressor, batch):


### PR DESCRIPTION
Thanks for doing such awesome work with the orb-models!  Interestingly, although trained unsupervised, predicted per-atom charges & dipoles using orbmol v2 give excellent infrared intensities! So exposing them is genuinely useful, which is what this PR does.
LatentChargeHead already computed per-atom charges and discarded them. This returns them as charges from predict(), and exposes charges plus a derived dipole through ORBCalculator, so atoms.get_charges() and atoms.get_dipole_moment() work.